### PR TITLE
Fix several bugs in dm_collector_c

### DIFF
--- a/dm_collector_c/dm_collector_c.cpp
+++ b/dm_collector_c/dm_collector_c.cpp
@@ -183,6 +183,7 @@ get_posix_timestamp () {
 // Return: successful or not
 static PyObject *
 dm_collector_c_disable_logs (PyObject *self, PyObject *args) {
+    (void)self;
     IdVector empty;
     BinaryBuffer buf;
     PyObject *serial_port = NULL;
@@ -312,6 +313,7 @@ generate_log_config_msgs (PyObject *file_or_serial, PyObject *type_names) {
 // If error occurs, false is returned and PyErr_SetString() will be called.
 static bool
 generate_log_config_headers (PyObject *file_or_serial, PyObject *type_names) {
+    (void)type_names;
     BinaryBuffer buf;
     IdVector empty;
     for (int k = 0; k < 12; k++) {
@@ -371,6 +373,7 @@ generate_log_config_headers (PyObject *file_or_serial, PyObject *type_names) {
 // If error occurs, false is returned and PyErr_SetString() will be called.
 static bool
 generate_log_config_ends (PyObject *file_or_serial, PyObject *type_names) {
+    (void)type_names;
     BinaryBuffer buf;
     IdVector empty;
     buf = encode_log_config(DIAG_END_6000, empty);
@@ -390,6 +393,7 @@ generate_log_config_ends (PyObject *file_or_serial, PyObject *type_names) {
 // Return: successful or not
 static PyObject *
 dm_collector_c_enable_logs (PyObject *self, PyObject *args) {
+    (void)self;
     PyObject *serial_port = NULL;
     PyObject *sequence = NULL;
     bool success = false;
@@ -427,6 +431,7 @@ dm_collector_c_enable_logs (PyObject *self, PyObject *args) {
 // Return: successful or not
 static PyObject *
 dm_collector_c_set_filtered_export (PyObject *self, PyObject *args) {
+    (void)self;
     const char *path;
     PyObject *sequence = NULL;
     IdVector type_ids;
@@ -461,6 +466,7 @@ dm_collector_c_set_filtered_export (PyObject *self, PyObject *args) {
 // Return: successful or not
 static PyObject *
 dm_collector_c_set_filtered (PyObject *self, PyObject *args) {
+    (void)self;
     PyObject *sequence = NULL;
     IdVector type_ids;
     bool success = false;
@@ -494,6 +500,7 @@ dm_collector_c_set_filtered (PyObject *self, PyObject *args) {
 // Return: successful or not
 static PyObject *
 dm_collector_c_generate_diag_cfg (PyObject *self, PyObject *args) {
+    (void)self;
     PyObject *file = NULL;
     PyObject *sequence = NULL;
     bool success = false;
@@ -565,6 +572,7 @@ dm_collector_c_generate_diag_cfg (PyObject *self, PyObject *args) {
 // Return: None
 static PyObject *
 dm_collector_c_feed_binary (PyObject *self, PyObject *args) {
+    (void)self;
     const char *b;
     int length;
     if (!PyArg_ParseTuple(args, "s#", &b, &length)){
@@ -577,6 +585,8 @@ dm_collector_c_feed_binary (PyObject *self, PyObject *args) {
 
 static PyObject *
 dm_collector_c_reset (PyObject *self, PyObject *args) {
+    (void)self;
+    (void)args;
     reset_binary();
     Py_RETURN_NONE;
 }
@@ -585,6 +595,7 @@ dm_collector_c_reset (PyObject *self, PyObject *args) {
 // Return: decoded_list or None
 static PyObject *
 dm_collector_c_receive_log_packet (PyObject *self, PyObject *args) {
+    (void)self;
     std::string frame;
     bool crc_correct = false;
     bool skip_decoding = false, include_timestamp = false;  // default values
@@ -695,7 +706,7 @@ initdm_collector_c(void)
     PyObject *log_packet_types;
 
     // dm_ccllector_c.log_packet_types: stores all supported type names
-    if(EXPOSE_INTERNAL_LOGS==1){
+    if(EXPOSE_INTERNAL_LOGS == 1) {
         //YUANJIE: expose all logs to MobileInsight
         int n_types = ARRAY_SIZE(LogPacketTypeID_To_Name, ValueName);
         log_packet_types = PyTuple_New(n_types);
@@ -712,17 +723,17 @@ initdm_collector_c(void)
         }
 
     }
-    else{
+    else {
         //YUANJIE: internal logs are not exposed
         int n_types = 0;
-        for (int i = 0; i < ARRAY_SIZE(LogPacketTypeID_To_Name, ValueName); i++)
+        for (int i = 0; i < (int)ARRAY_SIZE(LogPacketTypeID_To_Name, ValueName); i++)
         {
             if(LogPacketTypeID_To_Name[i].b_public)
                 n_types++;
         }
         log_packet_types = PyTuple_New(n_types);
         int count=0;
-        for (int i = 0; i < ARRAY_SIZE(LogPacketTypeID_To_Name, ValueName); i++)
+        for (int i = 0; i < (int)ARRAY_SIZE(LogPacketTypeID_To_Name, ValueName); i++)
         {
             if(LogPacketTypeID_To_Name[i].b_public){
                 // printf("%s\n",LogPacketTypeID_To_Name[i].name);

--- a/dm_collector_c/export_manager.cpp
+++ b/dm_collector_c/export_manager.cpp
@@ -45,6 +45,7 @@ manager_export_binary (struct ExportManagerState *pstate, const char *b, size_t 
         if (pstate->log_fp != NULL) {
             std::string frame = encode_hdlc_frame(b, (int) length);
             size_t cnt = fwrite(frame.c_str(), sizeof(char), frame.size(), pstate->log_fp);
+            (void)cnt;
         }
         return true;
     }

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -10,6 +10,7 @@
 #define __DM_COLLECTOR_C_LOG_PACKET_H__
 
 #include "consts.h"
+#include <stddef.h>
 
 // Field types
 enum FmtType {
@@ -987,10 +988,8 @@ const Fmt LteMacULBufferStatusInternal_SubpktHeaderFmt [] = {
 };
 
 const Fmt LteMacULBufferStatusInternal_ULBufferStatusSubPacket_SampleFmt [] = {
-    // Currently parsing half a byte is not supported
-    //{UINT, "SFN", 1.5},
-    //{UINT, "Sub FN", 0.5},
-    {UINT, "SFN and Sub FN", 2},
+    {UINT, "Sub FN", 2},
+    {PLACEHOLDER, "Sys FN", 0},
     {UINT, "Number of active LCID", 1}
 };
 
@@ -998,8 +997,25 @@ const Fmt LteMacULBufferStatusInternal_ULBufferStatusSubPacket_LCIDFmt [] = {
     {UINT, "Ld Id", 1},
     {UINT, "Priority", 1},
     {UINT, "New bytes", 4},
-    {UINT, "Ret bytes", 4},
+    {UINT, "Retx bytes", 4},
     {UINT, "Ctrl bytes", 2},
+};
+
+const Fmt LteMacULBufferStatusInternal_ULBufferStatusSubPacket_SampleFmt_v24 [] = {
+    {UINT, "Sub Id", 1},
+    {UINT, "Sub FN", 2},
+    {PLACEHOLDER, "Sys FN", 0},
+    {UINT, "Number of active LCID", 1}
+};
+
+const Fmt LteMacULBufferStatusInternal_ULBufferStatusSubPacket_LCIDFmt_v24 [] = {
+    {UINT, "Ld Id", 1},
+    {UINT, "Priority", 1},
+    {UINT, "New Uncompressed Bytes", 4},
+    {UINT, "New Compressed Bytes", 4},
+    {UINT, "Retx bytes", 4},
+    {UINT, "Ctrl bytes", 2},
+    {PLACEHOLDER, "Total Bytes", 0},
 };
 
 // ----------------------------------------------------------------------------

--- a/dm_collector_c/log_packet_helper.h
+++ b/dm_collector_c/log_packet_helper.h
@@ -66,6 +66,10 @@ _search_result(PyObject *result, const char *target) {
 // Find an integer field by its name in a result list, and return a C int with
 // the same value (overflow is ignored).
 // Return: int
+static int _search_result_int(
+        PyObject *result,
+        const char *target)
+    __attribute__ ((unused));
 static int
 _search_result_int(PyObject *result, const char *target) {
     PyObject *item = _search_result(result, target);
@@ -78,6 +82,10 @@ _search_result_int(PyObject *result, const char *target) {
 
 // This function should be called when the value is 4 bytes long.
 // Return: unsigned int
+static unsigned int _search_result_uint(
+        PyObject *result,
+        const char *target)
+    __attribute__ ((unused));
 static unsigned int
 _search_result_uint(PyObject *result, const char *target) {
     PyObject *item = _search_result(result, target);
@@ -107,6 +115,11 @@ _replace_result(PyObject *result, const char *target, PyObject *new_object) {
 
 // Find a field in a result list and replace it with an integer.
 // Return: New reference to the old object
+static PyObject * _replace_result_int(
+        PyObject *result,
+        const char *target,
+        int new_int)
+    __attribute__ ((unused));
 static PyObject *
 _replace_result_int(PyObject *result, const char *target, int new_int) {
     PyObject *pyint = Py_BuildValue("i", new_int);
@@ -120,6 +133,13 @@ _replace_result_int(PyObject *result, const char *target, int new_int) {
 // If there is no correponding string, or if the mapping is NULL, map this 
 // integer to *not_found*.
 // Return: old number
+static int _map_result_field_to_name(
+        PyObject *result,
+        const char *target,
+        const ValueName mapping [],
+        int n,
+        const char *not_found)
+    __attribute__ ((unused));
 static int
 _map_result_field_to_name(PyObject *result, const char *target,
                             const ValueName mapping [], int n,
@@ -147,6 +167,14 @@ _map_result_field_to_name(PyObject *result, const char *target,
 
 // Decode a binary string according to an array of field description (fmt[]).
 // Decoded fields are appended to result
+static int _decode_by_fmt (
+        const Fmt fmt [],
+        int n_fmt,
+        const char *b,
+        int offset,
+        int length,
+        PyObject *result)
+    __attribute__ ((unused));
 static int
 _decode_by_fmt (const Fmt fmt [], int n_fmt,
                 const char *b, int offset, int length,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,15 @@ PY2EXE_OPTIONS = {
     "bundle_files": 1, # bundle everything
 }
 
+# =============================================================================
+# Remove the "-Wstrict-prototypes" compiler option, which isn't valid for C++.
+import distutils.sysconfig
+cfg_vars = distutils.sysconfig.get_config_vars()
+for key, value in cfg_vars.items():
+        if type(value) == str:
+                    cfg_vars[key] = value.replace("-Wstrict-prototypes", "")
+# =============================================================================
+
 dm_collector_c_module = Extension('mobile_insight.monitor.dm_collector.dm_collector_c',
                                 sources = [ "dm_collector_c/dm_collector_c.cpp",
                                             "dm_collector_c/export_manager.cpp",


### PR DESCRIPTION
Add support for subpkt v24 of LTE_MAC_UL_Buffer_Status_Internal;
Bugs in LTE_PUSCH_Power_Control and LTE_PUCCH_Power_Control: should use & instead of &&;
Hide compile warning: unused variables and unused functions;
Remove "-Wstrict-prototypes" compiler option, which is not valid for C++.