### PR TITLE
update: API LteMacAnalyzer.UL_QUEUE_LENGTH, LteRlcAnalyzer.RLC_(UL/DL)_RB_(SETTING/NUMBER), LtePhyAnalyzer.PUSCH_TX_POWER

### DIFF
--- a/mobile_insight/analyzer/lte_mac_analyzer.py
+++ b/mobile_insight/analyzer/lte_mac_analyzer.py
@@ -249,7 +249,6 @@ class LteMacAnalyzer(Analyzer):
                                     self.log_info('MAC_RETX: ' + str(bcast_dict))
                                 else:
                                     self.failed_harq[id][-2] = True
-                                    rlc_retx += 1
                                     delay = sn_sfn - self.failed_harq[id][-1]
                                     # self.mac_retx.append(self.failed_harq[id] + [delay])
                                     bcast_dict = {}

--- a/mobile_insight/analyzer/lte_nas_analyzer.py
+++ b/mobile_insight/analyzer/lte_nas_analyzer.py
@@ -393,7 +393,10 @@ class LteNasAnalyzer(ProtocolAnalyzer):
                     if val.get('name') == 'nas_eps.emm.acc_csfb_cap':
                         csfb_cap = True if val.get('show') == '1' else False
                         self.log_info("CSFB Capbility: " + str(csfb_cap))
-                        self.broadcast_info('CSFB_CAP', str(csfb_cap))
+                        bcast_dict = {}
+                        bcast_dict['cafb cap'] = str(csfb_cap)
+                        bcast_dict['timestamp'] = str(msg.timestamp)
+                        self.broadcast_info('CSFB_CAP', bcast_dict)
 
 
             if field.get('show')=="EPS mobile identity - GUTI":

--- a/mobile_insight/analyzer/lte_phy_analyzer.py
+++ b/mobile_insight/analyzer/lte_phy_analyzer.py
@@ -200,7 +200,7 @@ class LtePhyAnalyzer(Analyzer):
                 bcast_dict = {}
                 bandwidth = self.lte_dl_bw / \
                     ((log_item['timestamp'] - self.prev_timestamp_dl).total_seconds() * 1000000.0)
-                pred_bandwidth = self.predict_bw()
+                pred_bandwidth = self.predict_bw(log_item['timestamp'])
                 bcast_dict['Bandwidth (Mbps)'] = str(round(bandwidth, 2))
 
                 # """
@@ -337,14 +337,17 @@ class LtePhyAnalyzer(Analyzer):
             self.lte_ul_bw = 0
             self.lte_ul_grant_utilized = 0
 
-    def predict_bw(self):
+    def predict_bw(self, timestamp):
         """
         Predict bandwidth based on CQI
         Currently it implements a naive solution based on pre-trained CQI->BW table
 
         """
         if self.cur_cqi0 in cqi_to_bw:
-            self.broadcast_info('PREDICTED_DL_BW', str(cqi_to_bw[self.cur_cqi0]))
+            bcast_dict = {}
+            bcast_dict['bandwidth'] = str(cqi_to_bw[self.cur_cqi0])
+            bcast_dict['timestamp'] = str(timestamp)
+            self.broadcast_info('PREDICTED_DL_BW', bcast_dict)
             self.log_info('PREDICTED_DL_BW: ' + str(cqi_to_bw[self.cur_cqi0]) + 'Mbps')
             return cqi_to_bw[self.cur_cqi0]
         else:

--- a/mobile_insight/analyzer/lte_phy_analyzer.py
+++ b/mobile_insight/analyzer/lte_phy_analyzer.py
@@ -97,14 +97,19 @@ class LtePhyAnalyzer(Analyzer):
         """
         log_item = msg.data.decode()
         # print log_item
-        # records = log_item['Records']
+        records = log_item['Records']
         timestamp = str(log_item['timestamp'])
 
         # TODO: Extract PUSCH tx power information and add broadcast to it
 
-        # for record in records:
+        for record in records:
         #     print record
-            # pusch_tx_power = record['PUSCH Tx Power (dBm)']
+            pusch_tx_power = record['PUSCH Tx Power (dBm)']
+            bcast_dict = {}
+            bcast_dict['tx power'] = pusch_tx_power
+            bcast_dict['timestamp'] = timestamp
+            self.broadcast_info("PUSCH_TX_POWER", bcast_dict)
+            self.log_info("PUSCH_TX_POWER: " + str(bcast_dict))
 
     def callback_pucch(self, msg):
         """
@@ -133,7 +138,7 @@ class LtePhyAnalyzer(Analyzer):
                 sr_dict['timestamp'] = timestamp
                 sr_dict['fn and subfn'] = record['Current SFN SF']
                 self.broadcast_info("SR_EVENT", sr_dict)
-                self.log_info("SR_EVENT" + str(sr_dict))
+                self.log_info("SR_EVENT: " + str(sr_dict))
             elif uciformat == 'Format 1B' or uciformat == 'Format 1A':
                 # TODO: reset init_flag for new logs
                 if self.init_flag:

--- a/mobile_insight/analyzer/lte_rlc_analyzer.py
+++ b/mobile_insight/analyzer/lte_rlc_analyzer.py
@@ -41,12 +41,41 @@ class LteRlcAnalyzer(Analyzer):
 
         if msg.type_id == "LTE_RLC_UL_Config_Log_Packet" or msg.type_id == "LTE_RLC_DL_Config_Log_Packet":
             log_item = msg.data.decode()
+            # print log_item
             subPkt = log_item['Subpackets'][0]
             if 'Released RBs' in subPkt:
                 for releasedRBItem in subPkt['Released RBs']:
                     rbConfigIdx = releasedRBItem['Released RB Cfg Index']
                     if rbConfigIdx in self.rbInfo:
                         self.rbInfo.pop(rbConfigIdx)
+            rb_num = 0
+            # print subPkt
+            for subpacket in subPkt['Active RBs']:
+                # print subpacket
+                rb_num += 1
+                lc_id = subpacket['LC ID']
+                ack_mode = subpacket['RB Mode']
+                rb_type = subpacket['RB Type']
+                bcast_dict = {}
+                bcast_dict['lcid'] = lc_id
+                bcast_dict['ack mode'] = ack_mode
+                bcast_dict['rb type'] = rb_type
+                bcast_dict['timstamp'] = str(log_item['timestamp'])
+                if msg.type_id == "LTE_RLC_UL_Config_Log_Packet":
+                    self.broadcast_info('RLC_UL_RB_SETTING', bcast_dict)
+                    self.log_info('RLC_UL_RB_SETTING: ' + str(bcast_dict))
+                else:
+                    self.broadcast_info('RLC_DL_RB_SETTING', bcast_dict)
+                    self.log_info('RLC_DL_RB_SETTING: ' + str(bcast_dict))
+            bcast_dict = {}
+            bcast_dict['number'] = str(rb_num)
+            bcast_dict['timstamp'] = str(log_item['timestamp'])
+            if msg.type_id == "LTE_RLC_UL_Config_Log_Packet":
+                self.broadcast_info('RLC_UL_RB_NUMBER', bcast_dict)
+                self.log_info('RLC_UL_RB_NUMBER: ' + str(bcast_dict))
+            else:
+                self.broadcast_info('RLC_DL_RB_NUMBER', bcast_dict)
+                self.log_info('RLC_DL_RB_NUMBER: ' + str(bcast_dict))
 
         if msg.type_id == "LTE_RLC_UL_AM_All_PDU":
             log_item = msg.data.decode()

--- a/mobile_insight/analyzer/lte_rrc_analyzer.py
+++ b/mobile_insight/analyzer/lte_rrc_analyzer.py
@@ -350,10 +350,10 @@ class LteRrcAnalyzer(ProtocolAnalyzer):
                 meas_report['timestamp'] = str(msg.timestamp)
                 for val in field.iter('field'):
                     if val.get('name') == 'lte-rrc.rsrpResult':
-                        meas_report['rsrp'] = int(val.get('show'))
-                        meas_report['rssi'] = meas_report['rsrp'] - 141 # map rsrp to rssi
+                        meas_report['rsrp'] = val.get('show')
+                        meas_report['rssi'] = str(int(meas_report['rsrp']) - 141) # map rsrp to rssi
                     elif val.get('name') == 'lte-rrc.rsrqResult':
-                        meas_report['rsrq'] = int(val.get('show'))
+                        meas_report['rsrq'] = val.get('show')
                 self.broadcast_info('MEAR_PCELL', meas_report)
                 self.log_info('MEAR_PCELL: ' + str(meas_report))
 
@@ -888,7 +888,6 @@ class LteRrcAnalyzer(ProtocolAnalyzer):
                 obj_id = int(field_val['lte-rrc.measObjectId'])
                 config_id = int(field_val['lte-rrc.reportConfigId'])
                 self.__config[cur_pair].active.measid_list[meas_id] = (obj_id,config_id)
-
 
 
     def __callback_rrc_conn(self,msg):


### PR DESCRIPTION
Testing results for these three APIs:

[INFO] [LteMacAnalyzer]: 2017-02-07 21:56:41.525133 UL_QUEUE_LENGTH: 1554
[INFO] [LteMacAnalyzer]: 2017-02-07 21:56:41.525133 UL_QUEUE_LENGTH: 938
[INFO] [LteMacAnalyzer]: 2017-02-07 21:56:41.525133 UL_QUEUE_LENGTH: 324

[INFO] [LteRlcAnalyzer]: RLC_DL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'SRB', 'lcid': 1, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_DL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'SRB', 'lcid': 2, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_DL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'DRB', 'lcid': 3, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_DL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'DRB', 'lcid': 4, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_DL_RB_NUMBER: {'number': '4', 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_UL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'SRB', 'lcid': 1, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_UL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'SRB', 'lcid': 2, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_UL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'DRB', 'lcid': 3, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_UL_RB_SETTING: {'ack mode': 'AM', 'rb type': 'DRB', 'lcid': 4, 'timstamp': '2017-02-07 21:56:56.371817'}
[INFO] [LteRlcAnalyzer]: RLC_UL_RB_NUMBER: {'number': '4', 'timstamp': '2017-02-07 21:56:56.371817'}

[INFO] [LtePhyAnalyzer]: PUSCH_TX_POWER: {'timestamp': '2017-02-07 21:56:22.688991', 'tx power': -18}
[INFO] [LtePhyAnalyzer]: PUCCH_TX_POWER: {'timestamp': '2017-02-07 21:56:22.698957', 'tx power': 26}
