### PR TITLE
Fix optimization 3.2

### DIFF
--- a/dm_collector_c/dm_collector_c.cpp
+++ b/dm_collector_c/dm_collector_c.cpp
@@ -602,7 +602,7 @@ dm_collector_c_receive_log_packet (PyObject *self, PyObject *args) {
     bool crc_correct = false;
     bool skip_decoding = false, include_timestamp = false;  // default values
     double posix_timestamp = (include_timestamp? get_posix_timestamp(): -1.0);
-    
+
     bool success = get_next_frame(frame, crc_correct);
     // printf("success=%d crc_correct=%d is_log_packet=%d\n", success, crc_correct, is_log_packet(frame.c_str(), frame.size()));
     // if (success && crc_correct && is_log_packet(frame.c_str(), frame.size())) {
@@ -623,7 +623,8 @@ dm_collector_c_receive_log_packet (PyObject *self, PyObject *args) {
                 Py_DECREF(arg_include_timestamp);
             }
 
-        manager_export_binary(&g_emanager, frame.c_str(), frame.size());
+        if (!manager_export_binary(&g_emanager, frame.c_str(), frame.size()))
+            Py_RETURN_NONE;
         if(is_log_packet(frame.c_str(), frame.size())){
             const char *s = frame.c_str();
             PyObject *decoded = decode_log_packet(s + 2,  // skip first two bytes

--- a/mobile_insight/monitor/android_dev_diag_monitor.py
+++ b/mobile_insight/monitor/android_dev_diag_monitor.py
@@ -468,7 +468,7 @@ class AndroidDevDiagMonitor(Monitor):
                                       type_id,
                                       packet)
                         self.send(event)
-                        del result, packet, event, d
+                        del result, packet, event
                     except FormatError as e:
                         # skip this packet
                         print "FormatError: ", e

--- a/mobile_insight/monitor/android_dev_diag_monitor.py
+++ b/mobile_insight/monitor/android_dev_diag_monitor.py
@@ -463,9 +463,9 @@ class AndroidDevDiagMonitor(Monitor):
                 if result:     # result = (decoded, posix_timestamp)
                     try:
                         packet = DMLogPacket(result[0])
-                        d = packet.decode()
+                        type_id = packet.get_type_id()
                         event = Event(result[1],
-                                      d["type_id"],
+                                      type_id,
                                       packet)
                         self.send(event)
                         del result, packet, event, d

--- a/mobile_insight/monitor/dm_collector/dm_collector.py
+++ b/mobile_insight/monitor/dm_collector/dm_collector.py
@@ -151,14 +151,14 @@ class DMCollector(Monitor):
                     try:
                         # packet = DMLogPacket(decoded)
                         packet = DMLogPacket(decoded[0])
-                        d = packet.decode()
+                        type_id = packet.get_type_id()
                         # print d["type_id"], d["timestamp"]
                         # xml = packet.decode_xml()
                         # print xml
                         # print ""
                         # Send event to analyzers
                         event = Event(timeit.default_timer(),
-                                      d["type_id"],
+                                      type_id,
                                       packet)
                         self.send(event)
                     except FormatError as e:

--- a/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
+++ b/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
@@ -357,10 +357,13 @@ class DMLogPacket:
         # d = cls._parse_internal_list("dict", self._decoded_list)
         # return d
 
-        if not self.decoded_cache:
-            cls = self.__class__
-            self.decoded_cache = cls._parse_internal_list("dict", self._decoded_list)
-        return self.decoded_cache
+        # if not self.decoded_cache:
+        #     cls = self.__class__
+        #     self.decoded_cache = cls._parse_internal_list("dict", self._decoded_list)
+        # return self.decoded_cache
+
+        cls = self.__class__
+        return cls._parse_internal_list("dict", self._decoded_list)
 
     def decode_xml(self):
         """
@@ -368,13 +371,19 @@ class DMLogPacket:
 
         :returns: a string that contains the converted XML document.
         """
-        if not self.decoded_json_cache:
-            cls = self.__class__
-            xml = cls._parse_internal_list("xml/dict", self._decoded_list)
-            # Zengwen: what about this name?
-            xml.tag = "dm_log_packet"
-            self.decoded_json_cache = ET.tostring(xml)
-        return self.decoded_json_cache
+        # if not self.decoded_json_cache:
+        #     cls = self.__class__
+        #     xml = cls._parse_internal_list("xml/dict", self._decoded_list)
+        #     # Zengwen: what about this name?
+        #     xml.tag = "dm_log_packet"
+        #     self.decoded_json_cache = ET.tostring(xml)
+        # return self.decoded_json_cache
+
+        cls = self.__class__
+        xml = cls._parse_internal_list("xml/dict", self._decoded_list)
+        # Zengwen: what about this name?
+        xml.tag = "dm_log_packet"
+        return ET.tostring(xml)
 
     def decode_json(self):
         """
@@ -383,19 +392,31 @@ class DMLogPacket:
         :returns: a string that contains the converted JSON document.
         """
 
-        if not self.decoded_json_cache:
-            cls = self.__class__
+        # if not self.decoded_json_cache:
+        #     cls = self.__class__
 
-            d = self.decode()
+        #     d = self.decode()
 
-            try:
-                import xmltodict
-                if "Msg" in d:
-                    d["Msg"] = xmltodict.parse(d["Msg"])
-            except ImportError:
-                pass
-            self.decoded_json_cache = json.dumps(d, cls=SuperEncoder)
-        return self.decoded_json_cache
+        #     try:
+        #         import xmltodict
+        #         if "Msg" in d:
+        #             d["Msg"] = xmltodict.parse(d["Msg"])
+        #     except ImportError:
+        #         pass
+        #     self.decoded_json_cache = json.dumps(d, cls=SuperEncoder)
+        # return self.decoded_json_cache
+
+        cls = self.__class__
+
+        d = self.decode()
+
+        try:
+            import xmltodict
+            if "Msg" in d:
+                d["Msg"] = xmltodict.parse(d["Msg"])
+        except ImportError:
+            pass
+        return json.dumps(d, cls=SuperEncoder)
 
     @classmethod
     def init(cls, prefs):

--- a/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
+++ b/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
@@ -74,12 +74,15 @@ class DMLogPacket:
         """
         cls = self.__class__
 
-        self._decoded_list = cls._preparse_internal_list(decoded_list)
+        self._decoded_list, self._type_id = cls._preparse_internal_list(decoded_list)
 
         # Optimization: Cache the decoded message. Avoid repetitive decoding
         self.decoded_cache = None
         self.decoded_xml_cache = None
         self.decoded_json_cache = None
+
+    def get_type_id(self):
+        return self._type_id
 
     @classmethod
     @static_var("wcdma_sib_types", {0: "RRC_MIB",
@@ -93,11 +96,14 @@ class DMLogPacket:
                                     })
     def _preparse_internal_list(cls, decoded_list):
         lst = []
+        type_id = ""
         try:
             # for i in range(len(decoded_list)):
             i = 0
             while i < len(decoded_list):
                 field_name, val, type_str = decoded_list[i]
+                if field_name == "type_id":
+                    type_id = val
                 if type_str.startswith("raw_msg/"):
                     msg_type = type_str[len("raw_msg/"):]
                     decoded = cls._decode_msg(msg_type, val)
@@ -155,7 +161,7 @@ class DMLogPacket:
                 else:
                     lst.append(decoded_list[i])
                 i = i + 1
-            return lst
+            return lst, type_id
 
         except Exception as e:
             print len(decoded_list)

--- a/mobile_insight/monitor/offline_replayer.py
+++ b/mobile_insight/monitor/offline_replayer.py
@@ -194,13 +194,13 @@ class OfflineReplayer(Monitor):
                             before_decode_time = time.time()
                             # self.log_info('Before decoding: ' + str(time.time()))
                             packet = DMLogPacket(decoded[0])
-                            d = packet.decode()
+                            type_id = packet.get_type_id()
                             after_decode_time = time.time()
                             decoding_inter += after_decode_time - before_decode_time
 
-                            if d["type_id"] in self._type_names:
+                            if type_id in self._type_names:
                                 event = Event(timeit.default_timer(),
-                                              d["type_id"],
+                                              type_id,
                                               packet)
                                 self.send(event)
                             after_sending_time = time.time()


### PR DESCRIPTION
1. Fix unnecessary decoding of non-enabled messages. (dm_collector_c/dm_collector_c.cpp).
2. Remove repetitive call of DMLogPacket.decode().
* add DMLogPacket.get_type_id() function by extracting type_id from _preparse_internal_list().
* Modify three analyzers: android_dev_diag_monitor, offline-replayer, dm_collector to get type_id using DMLogPacket.get_type_id() instead of call DMLogPacket.decode().
* Disable caching docode() results.