### PR TITLE
Update dm_collector to support more WCDMA signaling messages

### DIFF
--- a/dm_collector_c/dm_collector_c.cpp
+++ b/dm_collector_c/dm_collector_c.cpp
@@ -607,21 +607,23 @@ dm_collector_c_receive_log_packet (PyObject *self, PyObject *args) {
     // printf("success=%d crc_correct=%d is_log_packet=%d\n", success, crc_correct, is_log_packet(frame.c_str(), frame.size()));
     // if (success && crc_correct && is_log_packet(frame.c_str(), frame.size())) {
     if (success && crc_correct) {
-            PyObject *arg_skip_decoding = NULL;
-            PyObject *arg_include_timestamp = NULL;
-            if (!PyArg_ParseTuple(args, "|OO:receive_log_packet",
-                                        &arg_skip_decoding, &arg_include_timestamp))
-                return NULL;
-            if (arg_skip_decoding != NULL) {
-                Py_INCREF(arg_skip_decoding);
-                skip_decoding = (PyObject_IsTrue(arg_skip_decoding) == 1);
-                Py_DECREF(arg_skip_decoding);
-            }
-            if (arg_include_timestamp != NULL) {
-                Py_INCREF(arg_include_timestamp);
-                include_timestamp = (PyObject_IsTrue(arg_include_timestamp) == 1);
-                Py_DECREF(arg_include_timestamp);
-            }
+        PyObject *arg_skip_decoding = NULL;
+        PyObject *arg_include_timestamp = NULL;
+        if (!PyArg_ParseTuple(args, "|OO:receive_log_packet",
+                                    &arg_skip_decoding, &arg_include_timestamp))
+            return NULL;
+        if (arg_skip_decoding != NULL) {
+            Py_INCREF(arg_skip_decoding);
+            skip_decoding = (PyObject_IsTrue(arg_skip_decoding) == 1);
+            Py_DECREF(arg_skip_decoding);
+        }
+        if (arg_include_timestamp != NULL) {
+            Py_INCREF(arg_include_timestamp);
+            include_timestamp = (PyObject_IsTrue(arg_include_timestamp) == 1);
+            Py_DECREF(arg_include_timestamp);
+        }
+
+        check_frame_format(frame);
 
         if (!manager_export_binary(&g_emanager, frame.c_str(), frame.size()))
             Py_RETURN_NONE;

--- a/dm_collector_c/hdlc.cpp
+++ b/dm_collector_c/hdlc.cpp
@@ -141,3 +141,11 @@ get_next_frame (std::string& output_frame, bool& crc_correct) {
     crc_correct = (frame_crc16 == crc16);
     return true;
 }
+
+void
+check_frame_format (std::string& output_frame) {
+    size_t delim = output_frame.find("\x98\x01\x00\x00\x01\00\x00\x00");
+    if (delim == 0) {
+        output_frame.erase(0, 8);
+    }
+}

--- a/dm_collector_c/hdlc.h
+++ b/dm_collector_c/hdlc.h
@@ -7,5 +7,6 @@ std::string encode_hdlc_frame (const char *payld, int length);
 void feed_binary (const char *b, int length);
 void reset_binary ();
 bool get_next_frame (std::string& output_frame, bool& crc_correct);
+void check_frame_format (std::string& output_frame);
 
 #endif  // __DM_COLLECTOR_C_HDLC_H__

--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -105,7 +105,20 @@ _decode_wcdma_signaling_messages(const char *b, int offset, size_t length,
                 ARRAY_SIZE(ValueNameWcdmaExtraSIBType, ValueName),
                 ch_num);
         if (ch_name == NULL) {  // not found
-            printf("(MI)Unknown WCDMA Signalling Messages Extra Channel Type: 0x%x\n", ch_num);
+            printf("(MI)Unknown WCDMA Signalling Messages RRC Complete SIB Type: 0x%x\n", ch_num);
+            return 0;
+        }
+    } else if (0 == strncmp(ch_name, "Extension SIB", 13)) {
+        offset += _decode_by_fmt(WcdmaSignalingMessagesFmtExtensionSIBType,
+                ARRAY_SIZE(WcdmaSignalingMessagesFmtExtensionSIBType, Fmt),
+                b, offset, length, result);
+        pdu_length--;
+        int ch_num = _search_result_int(result, "Extension SIB Type");
+        ch_name = search_name(ValueNameWcdmaExtensionSIBType,
+                ARRAY_SIZE(ValueNameWcdmaExtensionSIBType, ValueName),
+                ch_num);
+        if (ch_name == NULL) {  // not found
+            printf("(MI)Unknown WCDMA Signalling Messages RRC Extension SIB Type: 0x%x\n", ch_num);
             return 0;
         }
     }

--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -5,41 +5,42 @@
 
 #include <Python.h>
 #include <datetime.h>
-#include <map>
-#include <string>
-#include <sstream>
 #include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <cstring>
 
-#include "consts.h"
-#include "log_packet.h"
-#include "log_packet_helper.h"
-#include "1xev_rx_partial_multirlp_packet.h"
 #include "1xev_connected_state_search_info.h"
 #include "1xev_connection_attempt.h"
 #include "1xev_connection_release.h"
-#include "lte_pdsch_stat_indication.h"
-#include "lte_phy_system_scan_results.h"
-#include "lte_phy_bplmn_cell_request.h"
-#include "lte_phy_bplmn_cell_confirm.h"
-#include "lte_phy_serving_cell_com_loop.h"
-#include "lte_phy_pdcch_decoding_result.h"
-#include "lte_phy_pdsch_decoding_result.h"
-#include "lte_phy_pusch_tx_report.h"
-#include "lte_phy_pucch_tx_report.h"
-#include "lte_phy_rlm_report.h"
-#include "lte_phy_pusch_csf.h"
-#include "lte_phy_cdrx_events_info.h"
-#include "wcdma_rrc_states.h"
-#include "lte_phy_idle_neighbor_cell_meas.h"
-#include "wcdma_search_cell_reselection_rank.h"
-#include "gsm_rr_cell_information.h"
-#include "gsm_surround_cell_ba_list.h"
-#include "gsm_rr_cell_reselection_meas.h"
-#include "srch_tng_1x_searcher_dump.h"
+#include "1xev_rx_partial_multirlp_packet.h"
 #include "1xevdo_multi_carrier_pilot_sets.h"
+#include "consts.h"
+#include "gsm_rr_cell_information.h"
+#include "gsm_rr_cell_reselection_meas.h"
+#include "gsm_surround_cell_ba_list.h"
+#include "log_packet.h"
+#include "log_packet_helper.h"
 #include "lte_pdcp_dl_cipher_data_pdu.h"
 #include "lte_pdcp_ul_cipher_data_pdu.h"
+#include "lte_pdsch_stat_indication.h"
+#include "lte_phy_bplmn_cell_confirm.h"
+#include "lte_phy_bplmn_cell_request.h"
+#include "lte_phy_cdrx_events_info.h"
+#include "lte_phy_idle_neighbor_cell_meas.h"
+#include "lte_phy_pdcch_decoding_result.h"
+#include "lte_phy_pdsch_decoding_result.h"
 #include "lte_phy_pucch_csf.h"
+#include "lte_phy_pucch_tx_report.h"
+#include "lte_phy_pusch_csf.h"
+#include "lte_phy_pusch_tx_report.h"
+#include "lte_phy_rlm_report.h"
+#include "lte_phy_serving_cell_com_loop.h"
+#include "lte_phy_system_scan_results.h"
+#include "srch_tng_1x_searcher_dump.h"
+#include "wcdma_rrc_states.h"
+#include "wcdma_search_cell_reselection_rank.h"
 
 #define SSTR( x ) static_cast< std::ostringstream & >( \
         ( std::ostringstream() << std::dec << x ) ).str()
@@ -81,10 +82,11 @@ static int
 _decode_wcdma_signaling_messages(const char *b, int offset, size_t length,
                                     PyObject *result) {
     (void)length;
+    int start = offset;
     int ch_num = _search_result_int(result, "Channel Type");
     const char *ch_name = search_name(WcdmaSignalingMsgChannelType,
-                                        ARRAY_SIZE(WcdmaSignalingMsgChannelType, ValueName),
-                                        ch_num);
+            ARRAY_SIZE(WcdmaSignalingMsgChannelType, ValueName),
+            ch_num);
 
     if (ch_name == NULL) {  // not found
         printf("(MI)Unknown WCDMA Signalling Messages Channel Type: 0x%x\n", ch_num);
@@ -93,13 +95,28 @@ _decode_wcdma_signaling_messages(const char *b, int offset, size_t length,
 
     int pdu_length = _search_result_int(result, "Message Length");
 
+    if (0 == strncmp(ch_name, "RRC_COMPLETE_SIB", 16)) {
+        offset += _decode_by_fmt(WcdmaSignalingMessagesFmtExtraSIBType,
+                ARRAY_SIZE(WcdmaSignalingMessagesFmtExtraSIBType, Fmt),
+                b, offset, length, result);
+        pdu_length--;
+        int ch_num = _search_result_int(result, "Extra SIB Type");
+        ch_name = search_name(ValueNameWcdmaExtraSIBType,
+                ARRAY_SIZE(ValueNameWcdmaExtraSIBType, ValueName),
+                ch_num);
+        if (ch_name == NULL) {  // not found
+            printf("(MI)Unknown WCDMA Signalling Messages Extra Channel Type: 0x%x\n", ch_num);
+            return 0;
+        }
+    }
+
     std::string type_str = "raw_msg/";
     type_str += ch_name;
     PyObject *t = Py_BuildValue("(ss#s)",
                                 "Msg", b + offset, pdu_length, type_str.c_str());
     PyList_Append(result, t);
     Py_DECREF(t);
-    return pdu_length;
+    return offset - start;
 }
 
 static int

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -84,6 +84,7 @@ const ValueName WcdmaSignalingMsgChannelType [] = {
     {0x04, "RRC_DL_BCCH_BCH"},
     {0x06, "RRC_DL_PCCH"},
     {0x09, "Extension SIB"},
+    {0x84, "RRC_DL_BCCH_BCH"},  // Qualcom makes duplicate constant?
     {0xfe, "RRC_COMPLETE_SIB"},
 };
 

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -92,6 +92,14 @@ const ValueName ValueNameWcdmaExtraSIBType [] = {
     {19, "RRC_SIB19"},
 };
 
+const Fmt WcdmaSignalingMessagesFmtExtensionSIBType [] = {
+    {UINT, "Extension SIB Type", 1},
+};
+
+const ValueName ValueNameWcdmaExtensionSIBType [] = {
+    {0x43, "RRC_SIB19"},    // Need more items here
+};
+
 const ValueName WcdmaSignalingMsgChannelType [] = {
     {0x00, "RRC_UL_CCCH"},
     {0x01, "RRC_UL_DCCH"},

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -76,6 +76,22 @@ const Fmt WcdmaSignalingMessagesFmt [] = {
     {UINT, "Message Length", 2}
 };
 
+const Fmt WcdmaSignalingMessagesFmtExtraSIBType [] = {
+    {UINT, "Extra SIB Type", 1},
+};
+
+const ValueName ValueNameWcdmaExtraSIBType [] = {
+    {0, "RRC_MIB"},
+    {1, "RRC_SIB1"},
+    {2, "RRC_SIB2"},
+    {3, "RRC_SIB3"},
+    {5, "RRC_SIB5"},
+    {7, "RRC_SIB7"},
+    {11, "RRC_SIB11"},
+    {12, "RRC_SIB12"},
+    {19, "RRC_SIB19"},
+};
+
 const ValueName WcdmaSignalingMsgChannelType [] = {
     {0x00, "RRC_UL_CCCH"},
     {0x01, "RRC_UL_DCCH"},

--- a/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
+++ b/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
@@ -91,6 +91,7 @@ class DMLogPacket:
                                     3: "RRC_SIB3",
                                     7: "RRC_SIB7",
                                     12: "RRC_SIB12",
+                                    22: "RRC_SIB15-3",
                                     27: "RRC_SB1",
                                     31: "RRC_SIB19",
                                     })
@@ -127,10 +128,14 @@ class DMLogPacket:
                             for complete_sib in sibs:
                                 field = complete_sib.find(
                                     "field[@name='rrc.sib_Type']")
+                                if not field:
+                                    continue
                                 sib_id = int(field.get("show"))
                                 sib_name = field.get("showname")
                                 field = complete_sib.find(
                                     "field[@name='rrc.sib_Data_variable']")
+                                if not field:
+                                    continue
                                 sib_msg = binascii.a2b_hex(field.get("value"))
                                 if sib_id in sib_types:
                                     decoded = cls._decode_msg(
@@ -138,7 +143,7 @@ class DMLogPacket:
                                     xmls.append(decoded)
                                     # print sib_types[sib_id]
                                 else:
-                                    print "Unknown RRC SIB Type: %d" % sib_id
+                                    print "(MI)Unknown RRC SIB Type: %d" % sib_id
                         else:
                             # deal with a segmented SIB
                             sib_segment = xml.find(

--- a/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
+++ b/mobile_insight/monitor/dm_collector/dm_endec/dm_log_packet.py
@@ -128,13 +128,13 @@ class DMLogPacket:
                             for complete_sib in sibs:
                                 field = complete_sib.find(
                                     "field[@name='rrc.sib_Type']")
-                                if not field:
+                                if field is None:
                                     continue
                                 sib_id = int(field.get("show"))
                                 sib_name = field.get("showname")
                                 field = complete_sib.find(
                                     "field[@name='rrc.sib_Data_variable']")
-                                if not field:
+                                if field is None:
                                     continue
                                 sib_msg = binascii.a2b_hex(field.get("value"))
                                 if sib_id in sib_types:

--- a/mobile_insight/monitor/dm_collector/dm_endec/ws_dissector.py
+++ b/mobile_insight/monitor/dm_collector/dm_endec/ws_dissector.py
@@ -45,6 +45,7 @@ class WSDissector:
         "RRC_SIB3": 153,
         "RRC_SIB5": 155,
         "RRC_SIB7": 157,
+        "RRC_SIB11": 161,
         "RRC_SIB12": 162,
         "RRC_SIB19": 169,
         # - WCDMA RRC SchedulingBlock
@@ -119,6 +120,7 @@ class WSDissector:
         """
         assert cls._init_proc_called
         if msg_type not in cls.SUPPORTED_TYPES:
+            print "MI(Unknown) Unsupported message for ws_dissector:", msg_type
             return None
 
         input_data = struct.pack(
@@ -143,16 +145,17 @@ class WSDissector:
 # Test decoding
 if __name__ == "__main__":
     tests = [("LTE-RRC_PCCH", "4001BF281AEBA00000"),
-             ("RRC_MIB", "60c428205aa2fe0090c8506e422419822a3653940c40c0"),
-             ("RRC_MIB", "10c424c05aa2fe00a0c850448c466608a8e54a80100a0100"),
-             ("RRC_SIB1", "c764b108500b1ba01483078a2be62ad0"),
-             ("RRC_SIB3", "0d801f4544fc60005001000011094e"),
-             ("RRC_SIB5", "63403AFFFF03FFFC5010F0290C0A8018000C8BF5B15EA0000003F5210E30000247894201400010440060222E56300C60202C000C14CC003C4300B6D830021844A0585760186AF400"),
-             ("RRC_SIB7", "018000"),
-             ("RRC_SIB12", "b38111d024541a42a0"),
-             ("RRC_SIB19", "41a1001694e49470"),
-             ]
+            ("RRC_MIB", "60c428205aa2fe0090c8506e422419822a3653940c40c0"),
+            ("RRC_MIB", "10c424c05aa2fe00a0c850448c466608a8e54a80100a0100"),
+            ("RRC_SIB1", "c764b108500b1ba01483078a2be62ad0"),
+            ("RRC_SIB3", "0d801f4544fc60005001000011094e"),
+            ("RRC_SIB5", "63403AFFFF03FFFC5010F0290C0A8018000C8BF5B15EA0000003F5210E30000247894201400010440060222E56300C60202C000C14CC003C4300B6D830021844A0585760186AF400"),
+            ("RRC_SIB7", "018000"),
+            ("RRC_SIB12", "b38111d024541a42a0"),
+            ("RRC_SIB19", "41a1001694e49470"),
+            ]
 
+    executable_path = None
     WSDissector.init_proc(executable_path, "/usr/local/lib")
 
     for typ, b in tests:

--- a/ws_dissector/packet-aww.cpp
+++ b/ws_dissector/packet-aww.cpp
@@ -36,6 +36,7 @@ static void init_proto_names (const char *protos []) {
     protos[153] = "rrc.si.sib3";
     protos[155] = "rrc.si.sib5";
     protos[157] = "rrc.si.sib7";
+    protos[161] = "rrc.si.sib11";
     protos[162] = "rrc.si.sib12";
     protos[169] = "rrc.si.sib19";
 


### PR DESCRIPTION
1. Check frame format after CRC check to get rid of "\x98\x01\x00\x00\x01\00\x00\x00" in some messages for unknown reason. Those messages are previously ignored.

2. Support RRC_Complete_SIB channel in WCDMA_RRC_OTA message, in previous implementation it is not parsed.

3. Support Extension SIB channel in WCDMA_RRC_OTA message, in previous implementation it is not parsed.