### PR TITLE
Add recognization for Qualcomm SDM chipset

### DIFF
--- a/mobile_insight/monitor/online_monitor.py
+++ b/mobile_insight/monitor/online_monitor.py
@@ -61,7 +61,7 @@ try:
         res = run_shell_cmd(cmd)
         if res.startswith("mt"):
             return ChipsetType.MTK
-        elif res.startswith("msm") or res.startswith("mdm"):
+        elif res.startswith("msm") or res.startswith("mdm") or res.startswith("sdm"):
             return ChipsetType.QUALCOMM
         else:
             print "WARNING: Unknown type:",res


### PR DESCRIPTION
The Qualcomm SDM845 code returned by `getprop ro.board.platform` is sdmXXX