### PR TITLE
lte_phy_analyser: prevent crashes when processing incomplete records

### DIFF
--- a/mobile_insight/analyzer/lte_mac_analyzer.py
+++ b/mobile_insight/analyzer/lte_mac_analyzer.py
@@ -111,10 +111,13 @@ class LteMacAnalyzer(Analyzer):
                                 break
 
                             for lcid in sample['LCIDs']:
-                                idx = lcid['Ld Id']
-                                new_bytes = int(lcid['New Compressed Bytes'])
-                                ctrl_bytes = int(lcid['Ctrl bytes'])
-                                total_bytes = int(lcid['Total Bytes'])
+                                try:
+                                    idx = lcid['Ld Id']
+                                    new_bytes = int(lcid['New Compressed Bytes'])
+                                    ctrl_bytes = int(lcid['Ctrl bytes'])
+                                    total_bytes = int(lcid['Total Bytes'])
+                                except KeyError:
+                                    continue
 
                                 if idx not in self.buffer:
                                     self.buffer[idx] = []
@@ -206,6 +209,7 @@ class LteMacAnalyzer(Analyzer):
                         crc_check = True if blocks['CRC Result'][-2:] == "ss" else False
                         tb_size = int(blocks['TB Size'])
                         rv_value = int(blocks['RV'])
+                        rlc_retx = 0
 
                         id = harq_id + cell_idx * 8 + tb_idx * 24
 

--- a/mobile_insight/analyzer/lte_phy_analyzer.py
+++ b/mobile_insight/analyzer/lte_phy_analyzer.py
@@ -97,8 +97,11 @@ class LtePhyAnalyzer(Analyzer):
         """
         log_item = msg.data.decode()
         # print log_item
-        records = log_item['Records']
-        timestamp = str(log_item['timestamp'])
+        try:
+            records = log_item['Records']
+            timestamp = str(log_item['timestamp'])
+        except KeyError:
+            return
 
         # TODO: Extract PUSCH tx power information and add broadcast to it
 


### PR DESCRIPTION
As in #52, generating json for offline analysis causes crashes when replaying logs where some records do not contain all fields.

I think I haven't quite yet found all the instances where this can happen, as I'm just fixing these as I run through the public data set.