### PR TITLE
Feat: support inserting custom package in mi3log

### DIFF
--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -6600,7 +6600,7 @@ is_debug_packet (const char *b, size_t length) {
 
 bool
 is_custom_packet (const char *b, size_t length) {
-    return length >= 2 && b[0] == '\xee';
+    return length >= 2 && b[0] == '\xee' && b[1] == '\xee';
 }
 
 void
@@ -7171,21 +7171,20 @@ decode_custom_packet (const char *b, size_t length) {
     offset += _decode_by_fmt(CustomPacketHeaderFmt, ARRAY_SIZE(LogPacketHeaderFmt, Fmt),
                                 b, offset, length, result);
 
-    std::string strTypeId = "Custom Packet";
+    std::string strTypeId = "Custom_Packet";
     PyObject *pystr = Py_BuildValue("s", strTypeId.c_str());
     PyObject *old_object = _replace_result(result, "type_id", pystr);
     Py_DECREF(old_object);
     Py_DECREF(pystr);
 
-    decode_custom_packet_payload(b+offset, length-offset, result);
+    decode_custom_packet_payload(b + offset, length - offset, result);
     return result;
 }
 
 void
 decode_custom_packet_payload (const char *b, size_t length, PyObject* result)
 {
-    std::string strPayload = "Custom Packet Payload";
-    PyObject *pystr = Py_BuildValue("s", strPayload.c_str());
+    PyObject *pystr = Py_BuildValue("s#", b, length);
     PyObject *old_object = _replace_result(result, "Msg", pystr);
     Py_DECREF(old_object);
     Py_DECREF(pystr);

--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -6598,7 +6598,12 @@ is_debug_packet (const char *b, size_t length) {
     // return length >=2 && (b[0] ==  '\x79');
 }
 
-void 
+bool
+is_custom_packet (const char *b, size_t length) {
+    return length >= 2 && b[0] == '\xee';
+}
+
+void
 on_demand_decode (const char *b, size_t length, LogPacketType type_id, PyObject* result)
 {
     int offset = 0;
@@ -7149,6 +7154,41 @@ decode_log_packet (const char *b, size_t length, bool skip_decoding) {
     on_demand_decode(b+offset, length-offset, type_id, result);
 
     return result;
+}
+
+PyObject *
+decode_custom_packet (const char *b, size_t length) {
+
+    if (PyDateTimeAPI == NULL)  // import datetime module
+        PyDateTime_IMPORT;
+
+    PyObject *result = NULL;
+    int offset = 0;
+
+    // Parse Header
+    result = PyList_New(0);
+    offset = 0;
+    offset += _decode_by_fmt(CustomPacketHeaderFmt, ARRAY_SIZE(LogPacketHeaderFmt, Fmt),
+                                b, offset, length, result);
+
+    std::string strTypeId = "Custom Packet";
+    PyObject *pystr = Py_BuildValue("s", strTypeId.c_str());
+    PyObject *old_object = _replace_result(result, "type_id", pystr);
+    Py_DECREF(old_object);
+    Py_DECREF(pystr);
+
+    decode_custom_packet_payload(b+offset, length-offset, result);
+    return result;
+}
+
+void
+decode_custom_packet_payload (const char *b, size_t length, PyObject* result)
+{
+    std::string strPayload = "Custom Packet Payload";
+    PyObject *pystr = Py_BuildValue("s", strPayload.c_str());
+    PyObject *old_object = _replace_result(result, "Msg", pystr);
+    Py_DECREF(old_object);
+    Py_DECREF(pystr);
 }
 
 /*-----------------------------------------------------------------------

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -43,11 +43,10 @@ const Fmt LogPacketHeaderFmt [] = {
 };
 
 const Fmt CustomPacketHeaderFmt [] = {
-    {SKIP, NULL, 2},
     {UINT, "log_msg_len", 2},
     {UINT, "type_id", 2},
     {QCDM_TIMESTAMP, "timestamp", 8},
-    {SKIP, "Msg", 0},
+    {PLACEHOLDER, "Msg", 0},
 };
 
 //Yuanjie: the following comments are my suggestions for field name replacement

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -42,6 +42,14 @@ const Fmt LogPacketHeaderFmt [] = {
     {QCDM_TIMESTAMP, "timestamp", 8}
 };
 
+const Fmt CustomPacketHeaderFmt [] = {
+    {SKIP, NULL, 2},
+    {UINT, "log_msg_len", 2},
+    {UINT, "type_id", 2},
+    {QCDM_TIMESTAMP, "timestamp", 8},
+    {SKIP, "Msg", 0},
+};
+
 //Yuanjie: the following comments are my suggestions for field name replacement
 //No change if the comments are missing
 
@@ -2955,11 +2963,15 @@ const Fmt ModemDebug_Fmt [] = {
 
 bool is_log_packet (const char *b, size_t length);
 bool is_debug_packet (const char *b, size_t length);   //Yuanjie: test if it's a debugging message
+bool is_custom_packet (const char *b, size_t length);
 
 // Given a binary string, try to decode it as a log packet.
 // Return a specailly formatted Python list that stores the decoding result.
 // If skip_decoding is True, only the header would be decoded.
 PyObject * decode_log_packet (const char *b, size_t length, bool skip_decoding);
+
+PyObject * decode_custom_packet (const char *b, size_t length);
+void decode_custom_packet_payload (const char *b, size_t length, PyObject* result);
 
 void on_demand_decode (const char *b, size_t length, LogPacketType type_id, PyObject* result);
 

--- a/mobile_insight/monitor/dm_collector/dm_endec/ws_dissector.py
+++ b/mobile_insight/monitor/dm_collector/dm_endec/ws_dissector.py
@@ -122,6 +122,9 @@ class WSDissector:
         if msg_type not in cls.SUPPORTED_TYPES:
             print "MI(Unknown) Unsupported message for ws_dissector:", msg_type
             return None
+        if len(b) > 500:
+            print "MI(Ignore) Length of message is too large for ws_dissector:", len(b), "bytes"
+            return None
 
         input_data = struct.pack(
             "!II",  # in network order

--- a/mobile_insight/monitor/offline_replayer.py
+++ b/mobile_insight/monitor/offline_replayer.py
@@ -198,7 +198,7 @@ class OfflineReplayer(Monitor):
                             after_decode_time = time.time()
                             decoding_inter += after_decode_time - before_decode_time
 
-                            if type_id in self._type_names:
+                            if type_id in self._type_names or type_id == "Custom_Packet":
                                 event = Event(timeit.default_timer(),
                                               type_id,
                                               packet)

--- a/mobile_insight/monitor/offline_replayer.py
+++ b/mobile_insight/monitor/offline_replayer.py
@@ -182,13 +182,15 @@ class OfflineReplayer(Monitor):
                 dm_collector_c.reset()
                 while True:
                     s = self._input_file.read(64)
-                    if not s:   # EOF encountered
-                        break
 
-                    dm_collector_c.feed_binary(s)
+                    if s:
+                        dm_collector_c.feed_binary(s)
                     decoded = dm_collector_c.receive_log_packet(self._skip_decoding,
                                                                 True,   # include_timestamp
                                                                 )
+                    if not s and not decoded:   # EOF encountered and no message can be received any more
+                        break
+
                     if decoded:
                         try:
                             before_decode_time = time.time()


### PR DESCRIPTION
1. This patch allows android_dev_diag_monitor to insert custom package into mi2log file at run-time with qcdm timestamp. I named the new file type as mi3log so it can differentiate with mi2log. It may be useful to insert any timestamp sensitive message to bypass timestamp synchronization issue.
2. It supports both encoding and decoding.
3. It won't be enabled and no mi3log files will be generated unless android_dev_diag_monitor._enable_mi3log() is called. All mi3log will be saved to cache directory at the same pace and same filename (1.mi3log, 2.mi3log, 3.mi3log ... just like what diag_revealer does) as mi2log. Plugin also needs to take care log saving.
4. To insert a custom packet: android_dev_diag_monitor._insert_custom_packet("Hello World, I am a custom packet")
5. The inserting of one packet is atomic and delay sensitive.
6. Regarding decoding, there is no need to enable any new message, it will always be decoded and send as element.Event as long as skip_decoding is false.
7. The structure of custom package looks like this:
    type_id: "Custom_Packet"
    data:{'timestamp': qcdm timestamp, 'Msg': custom message content}

 