### PR TITLE
Add decoding support for mi3log custom packet

### DIFF
--- a/dm_collector_c/dm_collector_c.cpp
+++ b/dm_collector_c/dm_collector_c.cpp
@@ -613,95 +613,121 @@ dm_collector_c_receive_log_packet(PyObject *self, PyObject *args) {
     bool crc_correct = false;
     bool skip_decoding = false, include_timestamp = false;  // default values
     double posix_timestamp = (include_timestamp ? get_posix_timestamp() : -1.0);
+    bool success = true;
+    PyObject *arg_skip_decoding = NULL;
+    PyObject *arg_include_timestamp = NULL;
 
-    bool success = get_next_frame(frame, crc_correct);
-    // printf("success=%d crc_correct=%d is_log_packet=%d\n", success, crc_correct, is_log_packet(frame.c_str(), frame.size()));
-    // if (success && crc_correct && is_log_packet(frame.c_str(), frame.size())) {
-    if (success && crc_correct) {
-        PyObject *arg_skip_decoding = NULL;
-        PyObject *arg_include_timestamp = NULL;
-        if (!PyArg_ParseTuple(args, "|OO:receive_log_packet",
-                              &arg_skip_decoding, &arg_include_timestamp))
-            Py_RETURN_NONE;
-        if (arg_skip_decoding != NULL) {
-            Py_INCREF(arg_skip_decoding);
-            skip_decoding = (PyObject_IsTrue(arg_skip_decoding) == 1);
-            Py_DECREF(arg_skip_decoding);
-        }
-        if (arg_include_timestamp != NULL) {
-            Py_INCREF(arg_include_timestamp);
-            include_timestamp = (PyObject_IsTrue(arg_include_timestamp) == 1);
-            Py_DECREF(arg_include_timestamp);
-        }
+    if (!PyArg_ParseTuple(args, "|OO:receive_log_packet",
+                          &arg_skip_decoding, &arg_include_timestamp))
+        Py_RETURN_NONE;
+    if (arg_skip_decoding != NULL) {
+        Py_INCREF(arg_skip_decoding);
+        skip_decoding = (PyObject_IsTrue(arg_skip_decoding) == 1);
+        Py_DECREF(arg_skip_decoding);
+    }
+    if (arg_include_timestamp != NULL) {
+        Py_INCREF(arg_include_timestamp);
+        include_timestamp = (PyObject_IsTrue(arg_include_timestamp) == 1);
+        Py_DECREF(arg_include_timestamp);
+    }
 
-        check_frame_format(frame);
+    while (success) {
+        // Keep reading the buffer in case there are any frames remained.
 
-        if (!manager_export_binary(&g_emanager, frame.c_str(), frame.size()))
-            Py_RETURN_NONE;
-        if (is_log_packet(frame.c_str(), frame.size())) {
-            const char *s = frame.c_str();
-            PyObject *decoded = decode_log_packet(s + 2,  // skip first two bytes
-                                                  frame.size() - 2,
-                                                  skip_decoding);
-            if (include_timestamp) {
-                PyObject *ret = Py_BuildValue("(Od)", decoded, posix_timestamp);
-                Py_XDECREF(decoded);
-                return ret;
-            } else {
-                return decoded;
+        success = get_next_frame(frame, crc_correct);
+        // printf("success=%d crc_correct=%d is_log_packet=%d\n", success, crc_correct, is_log_packet(frame.c_str(), frame.size()));
+        // if (success && crc_correct && is_log_packet(frame.c_str(), frame.size())) {
+        //
+
+        if (success && crc_correct) {
+
+            check_frame_format(frame);
+
+            // Check if it is custom packet
+            if(is_custom_packet(frame.c_str(), frame.size())) {
+                if (skip_decoding) {
+                    Py_RETURN_NONE;
+                }
+                const char *s = frame.c_str();
+                PyObject *decoded = decode_custom_packet(s + 2,  // skip first two bytes
+                                                      frame.size() - 2);
+                if (include_timestamp) {
+                    PyObject *ret = Py_BuildValue("(Od)", decoded, posix_timestamp);
+                    Py_DECREF(decoded);
+                    return ret;
+                } else {
+                    return decoded;
+                }
             }
-        } else if (is_debug_packet(frame.c_str(), frame.size())) {
-            //Yuanjie: the original debug msg does not have header...
 
-            unsigned short n_size = frame.size() + sizeof(char) * 14;
+            if (!manager_export_binary(&g_emanager, frame.c_str(), frame.size()))
+                continue;
+            if (is_log_packet(frame.c_str(), frame.size())) {
+                const char *s = frame.c_str();
+                PyObject *decoded = decode_log_packet(s + 2,  // skip first two bytes
+                                                      frame.size() - 2,
+                                                      skip_decoding);
+                if (include_timestamp) {
+                    PyObject *ret = Py_BuildValue("(Od)", decoded, posix_timestamp);
+                    Py_DECREF(decoded);
+                    return ret;
+                } else {
+                    return decoded;
+                }
+            } else if (is_debug_packet(frame.c_str(), frame.size())) {
+                //Yuanjie: the original debug msg does not have header...
 
-            unsigned char tmp[14] = {
+                unsigned short n_size = frame.size()+sizeof(char)*14;
+
+                unsigned char tmp[14]={
                     0xFF, 0xFF,
                     0x00, 0x00, 0xeb, 0x1f,
                     0x00, 0x00, 0x73, 0xB7,
                     0xB8, 0x65, 0xDD, 0x00
-            };
-            // tmp[2]=(char)(n_size);
-            *(tmp + 2) = n_size;
-            *(tmp) = n_size;
-            char *s = new char[n_size];
-            memmove(s, tmp, sizeof(char) * 14);
-            memmove(s + sizeof(char) * 14, frame.c_str(), frame.size());
-            PyObject *decoded = decode_log_packet_modem(s, n_size, skip_decoding);
+                };
+                // tmp[2]=(char)(n_size);
+                *(tmp+2)=n_size;
+                *(tmp)=n_size;
+                char *s = new char[n_size];
+                memmove(s,tmp,sizeof(char)*14);
+                memmove(s+sizeof(char)*14,frame.c_str(),frame.size());
+                PyObject *decoded = decode_log_packet_modem(s, n_size, skip_decoding);
 
-            // char *s = new char[n_size];
-            // memset(s,0,sizeof(char)*n_size);
-            // *s = n_size;
-            // *(s+2) = n_size;
-            // *(s+4) = 0xeb;
-            // *(s+5) = 0x1f;
-            // memmove(s+sizeof(char)*14,frame.c_str(),frame.size());
-            // PyObject *decoded = decode_log_packet(s, n_size, skip_decoding);
+                // char *s = new char[n_size];
+                // memset(s,0,sizeof(char)*n_size);
+                // *s = n_size;
+                // *(s+2) = n_size;
+                // *(s+4) = 0xeb;
+                // *(s+5) = 0x1f;
+                // memmove(s+sizeof(char)*14,frame.c_str(),frame.size());
+                // PyObject *decoded = decode_log_packet(s, n_size, skip_decoding);
 
 
 
-            // // The following code does not crash on Android.
-            // // But if use s and frame.size(), it crashes
-            // const char *s = frame.c_str();
-            // PyObject *decoded = decode_log_packet(  s + 2,  // skip first two bytes
-            //                                         frame.size() - 2,
-            //                                         skip_decoding);
+                // // The following code does not crash on Android.
+                // // But if use s and frame.size(), it crashes
+                // const char *s = frame.c_str();
+                // PyObject *decoded = decode_log_packet(  s + 2,  // skip first two bytes
+                //                                         frame.size() - 2,
+                //                                         skip_decoding);
 
-            if (include_timestamp) {
-                PyObject *ret = Py_BuildValue("(Od)", decoded, posix_timestamp);
-                Py_DECREF(decoded);
-                // delete [] s; //Yuanjie: bug for it on Android, but no problem on laptop
-                return ret;
+                if (include_timestamp) {
+                    PyObject *ret = Py_BuildValue("(Od)", decoded, posix_timestamp);
+                    Py_DECREF(decoded);
+                    // delete [] s; //Yuanjie: bug for it on Android, but no problem on laptop
+                    return ret;
+                } else {
+                    // delete [] s; //Yuanjie: bug for it on Android, but no problem on laptop
+                    return decoded;
+                }
             } else {
-                // delete [] s; //Yuanjie: bug for it on Android, but no problem on laptop
-                return decoded;
+                continue;
             }
         } else {
-            Py_RETURN_NONE;
+            continue;
         }
-    } else {
-        Py_RETURN_NONE;
     }
+    Py_RETURN_NONE;
 }
 
 // Init the module

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -42,6 +42,13 @@ const Fmt LogPacketHeaderFmt[] = {
         {QCDM_TIMESTAMP, "timestamp",   8}
 };
 
+const Fmt CustomPacketHeaderFmt [] = {
+    {UINT, "log_msg_len", 2},
+    {UINT, "type_id", 2},
+    {QCDM_TIMESTAMP, "timestamp", 8},
+    {PLACEHOLDER, "Msg", 0},
+};
+
 //Yuanjie: the following comments are my suggestions for field name replacement
 //No change if the comments are missing
 
@@ -4206,10 +4213,15 @@ bool is_log_packet(const char *b, size_t length);
 
 bool is_debug_packet(const char *b, size_t length);    //Yuanjie: test if it's a debugging message
 
+bool is_custom_packet (const char *b, size_t length);
+
 // Given a binary string, try to decode it as a log packet.
 // Return a specially formatted Python list that stores the decoding result.
 // If skip_decoding is True, only the header would be decoded.
 PyObject *decode_log_packet(const char *b, size_t length, bool skip_decoding);
+
+PyObject * decode_custom_packet (const char *b, size_t length);
+void decode_custom_packet_payload (const char *b, size_t length, PyObject* result);
 
 void on_demand_decode(const char *b, size_t length, LogPacketType type_id, PyObject *result);
 

--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -45,7 +45,7 @@ fi
 echo "Configuring Wireshark sources for ws_dissector compilation..."
 cd ${WIRESHARK_SRC_PATH}
 ./configure --disable-wireshark > /dev/null 2>&1
-if [[ $? != 0 ]]; then
+if [ $? != 0 ]; then
     echo "Error when executing '${WIRESHARK_SRC_PATH}/configure --disable-wireshark'."
     echo "You need to manually fix it before continuation. Exiting with status 3"
     exit 3
@@ -78,15 +78,17 @@ fi
 
 if [ "$FindWiresharkLibrary" = false ] ; then
     echo "Compiling wireshark-${ws_ver} from source code, it may take a few minutes..."
-    make > /dev/null 2>&1
-    if [[ $? != 0 ]]; then
+    # make -j8 > /dev/null 2>&1
+    NPROC=$(nproc)
+    make -j$NPROC
+    if [ $? != 0 ]; then
         echo "Error when compiling wireshark-${ws_ver} from source code'."
         echo "You need to manually fix it before continuation. Exiting with status 2"
         exit 2
     fi
     echo "Installing wireshark-${ws_ver}"
     sudo make install > /dev/null 2>&1
-    if [[ $? != 0 ]]; then
+    if [ $? != 0 ]; then
         echo "Error when installing wireshark-${ws_ver} compiled from source code'."
         echo "You need to manually fix it before continuation. Exiting with status 2"
         exit 2
@@ -113,9 +115,9 @@ sudo chmod 755 ${PREFIX}/bin/ws_dissector
 
 echo "Installing dependencies for mobileinsight GUI..."
 sudo apt-get -y install python-wxgtk3.0
-which pip
-if [[ $? != 0 ]] ; then
-    sudo apt-get -y install python-pip
+which pip3
+if [ $? != 0 ]; then
+    sudo apt-get -y install python3-pip
 fi
 if ${PIP} install matplotlib pyserial > /dev/null; then
     echo "pyserial and matplotlib are successfully installed!"
@@ -139,7 +141,7 @@ sudo ln -s ${PREFIX}/share/mobileinsight/mi-gui ${PREFIX}/bin/mi-gui
 echo "Testing the MobileInsight offline analysis example."
 cd ${MOBILEINSIGHT_PATH}/examples
 ${PYTHON} offline-analysis-example.py
-if [[ $? == 0 ]] ; then
+if [ $? -eq 0 ]; then
     echo "Successfully ran the offline analysis example!"
 else
     echo "Failed to run offline analysis example!"


### PR DESCRIPTION
1. Enable parsing support for Custom_Packet (pre-header: 0xEEEE,  same level as normal Log_Packet and Debug_Packet)
2. Update install-ubuntu.sh to avoid complaint
3. Fix bug in dm_collector and offline_replayer: when there are multiple frames with total length < 64 bytes, only the first frame is processed by dm_collector and following frames are ignored. 