### PR TITLE
Update ws_dissector to support Wireshark 3.2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ examples/lte-rrc-example.py
 
 # Wireshark sources
 wireshark-2.*/
+wireshark-3.*/
 
 .idea/

--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -11,8 +11,8 @@
 echo "** Installer Script for mobileinsight-core on Ubuntu **"
 echo " "
 echo "  Author : Zengwen Yuan (zyuan [at] cs.ucla.edu), Haotian Deng (deng164 [at] purdue.edu)"
-echo "  Date   : 2017-11-13"
-echo "  Rev    : 3.0"
+echo "  Date   : 2020-10-20"
+echo "  Rev    : 4.0"
 echo "  Usage  : ./install-ubuntu.sh"
 echo " "
 
@@ -20,7 +20,7 @@ echo "Upgrading MobileInsight..."
 yes | ./uninstall.sh
 
 # Wireshark version to install
-ws_ver=2.0.13
+ws_ver=3.2.7
 
 # Use local library path
 #TODO
@@ -37,14 +37,14 @@ sudo apt-get -y install pkg-config wget libglib2.0-dev bison flex libpcap-dev
 echo "Checking Wireshark sources to compile ws_dissector"
 if [ ! -d "${WIRESHARK_SRC_PATH}" ]; then
     echo "You do not have source codes for Wireshark version ${ws_ver}, downloading..."
-    wget https://www.wireshark.org/download/src/all-versions/wireshark-${ws_ver}.tar.bz2
-    tar -xjvf wireshark-${ws_ver}.tar.bz2
-    rm wireshark-${ws_ver}.tar.bz2
+    wget https://www.wireshark.org/download/src/all-versions/wireshark-${ws_ver}.tar.xz
+    tar -xf wireshark-${ws_ver}.tar.xz
+    rm wireshark-${ws_ver}.tar.xz
 fi
 
 echo "Configuring Wireshark sources for ws_dissector compilation..."
 cd ${WIRESHARK_SRC_PATH}
-./configure --disable-wireshark > /dev/null 2>&1
+cmake --disable-wireshark . > /dev/null 2>&1
 if [ $? != 0 ]; then
     echo "Error when executing '${WIRESHARK_SRC_PATH}/configure --disable-wireshark'."
     echo "You need to manually fix it before continuation. Exiting with status 3"
@@ -55,32 +55,30 @@ echo "Check if proper version of wireshark dynamic library exists in system path
 
 FindWiresharkLibrary=true
 
-if readelf -d "/usr/local/lib/libwireshark.so" | grep "SONAME" | grep "libwireshark.so.7" ; then
-    echo "Found libwireshark.so.7 being used"
+if readelf -d "/usr/local/lib/libwireshark.so" | grep "SONAME" | grep "libwireshark.so.13" ; then
+    echo "Found libwireshark.so.13 being used"
 else
-    echo "Didn't find libwireshark.so.7"
+    echo "Didn't find libwireshark.so.13"
     FindWiresharkLibrary=false
 fi
 
-if readelf -d "/usr/local/lib/libwiretap.so" | grep "SONAME" | grep "libwiretap.so.5" ; then
-    echo "Found libwiretap.so.5 being used"
+if readelf -d "/usr/local/lib/libwiretap.so" | grep "SONAME" | grep "libwiretap.so.10" ; then
+    echo "Found libwiretap.so.10 being used"
 else
-    echo "Didn't find libwiretap.so.5"
+    echo "Didn't find libwiretap.so.10"
     FindWiresharkLibrary=false
 fi
 
-if readelf -d "/usr/local/lib/libwsutil.so" | grep "SONAME" | grep "libwsutil.so.6" ; then
-    echo "Found libwsutil.so.6 being used"
+if readelf -d "/usr/local/lib/libwsutil.so" | grep "SONAME" | grep "libwsutil.so.11" ; then
+    echo "Found libwsutil.so.11 being used"
 else
-    echo "Didn't find libwsutil.so.6"
+    echo "Didn't find libwsutil.so.11"
     FindWiresharkLibrary=false
 fi
 
 if [ "$FindWiresharkLibrary" = false ] ; then
     echo "Compiling wireshark-${ws_ver} from source code, it may take a few minutes..."
-    # make -j8 > /dev/null 2>&1
-    NPROC=$(nproc)
-    make -j$NPROC
+    make -j $(grep -c ^processor /proc/cpuinfo)
     if [ $? != 0 ]; then
         echo "Error when compiling wireshark-${ws_ver} from source code'."
         echo "You need to manually fix it before continuation. Exiting with status 2"

--- a/ws_dissector/packet-aww.cpp
+++ b/ws_dissector/packet-aww.cpp
@@ -1,12 +1,13 @@
 #include "config.h"
 #include <epan/epan.h>
 #include <epan/packet.h>
+#include <epan/proto_data.h>
 #include <epan/dissectors/packet-pdcp-lte.h>
 
 #include <stdio.h>
 #include "packet-aww.h"
 
-#define WS_DISSECTOR_VERSION "2.0.1"
+#define WS_DISSECTOR_VERSION "3.2.7"
 
 static const int PROTO_MAX = 1000;
 
@@ -185,8 +186,8 @@ dissect_extra_pdcp_lte_info(tvbuff_t *tvb, packet_info *pinfo, gint32 offset)
 }
 
 
-static void
-dissect_aww(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
+static int
+dissect_aww(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data)
 {
     col_set_str(pinfo->cinfo, COL_PROTOCOL, "Automator Wireshark Wrapper");
     /* Clear out stuff in the info column */
@@ -217,6 +218,7 @@ dissect_aww(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
             }
         }
     }
+    return tvb_reported_length(tvb);
 }
 
 
@@ -250,6 +252,7 @@ proto_register_aww(void)
     proto_table = register_dissector_table(
                     "aww.proto",
                     "AWW protocol",
+                    proto_aww,
                     FT_UINT16,
                     BASE_DEC
                     );
@@ -271,14 +274,7 @@ proto_reg_handoff_aww(void)
     dissector_handle_t handle = NULL;
     for (int i = 0; i <= PROTO_MAX; i++) {
         if (protos[i] != NULL) {
-            handle = NULL;
             handle = find_dissector(protos[i]);
-            // printf ("[MoonSky]: find_dissector[%s]: ", protos[i]);
-            // if (handle != NULL) {
-            //     printf ("Success\n");
-            // } else {
-            //     printf ("Fail\n");
-            // }
             dissector_add_uint("aww.proto", i, handle);
         }
     }


### PR DESCRIPTION
1. Update ws_dissector to target Wireshark 3.2.7
2. Update install-ubuntu.sh to use Wireshark 3.2.7 for ws_dissector compiling.
3. Please note install-macos.sh also needs to update so that it can use the latest Wireshark 3.2.7 for ws_dissector.
@yuanjieli :  Please be aware that we may need to update some standard analyzer code as the new Wireshark library changed name of some fields. For example, the lte_rrc_analyzer.py get an exception caused by one change in lte-rrc.CarrierFreqUTRA_FDD_element:
lte-rrc.q_RxLevMin ==> lte-rrc.utra_q_RxLevMin