### PR TITLE
Bug fixing for mi-gui

### DIFF
--- a/gui/mi-gui
+++ b/gui/mi-gui
@@ -1,1 +1,1 @@
-python2 /usr/local/share/mobileinsight/mobile_insight_gui.py
+python3 /usr/local/share/mobileinsight/mobile_insight_gui.py


### PR DESCRIPTION
Bug fixing for mi-gui.

wxPython should be installed for using mi-gui.
To install wxPython:

- https://www.wxpython.org/pages/downloads/
- Installing libsdl2 on linux:
   ```
   sudo apt-get install git curl libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
   ```