### PR TITLE
fixed install-ubuntu by replacing --disable-wireshark with -DBUILD_wireshark

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -44,9 +44,9 @@ fi
 
 echo "Configuring Wireshark sources for ws_dissector compilation..."
 cd ${WIRESHARK_SRC_PATH}
-cmake --disable-wireshark . > /dev/null 2>&1
+cmake -DBUILD_wireshark=OFF . > /dev/null 2>&1
 if [ $? != 0 ]; then
-    echo "Error when executing '${WIRESHARK_SRC_PATH}/configure --disable-wireshark'."
+    echo "Error when executing '${WIRESHARK_SRC_PATH}/cmake -DBUILD_wireshark .'"
     echo "You need to manually fix it before continuation. Exiting with status 3"
     exit 3
 fi


### PR DESCRIPTION

install-ubuntu script was using --disable-wireshark argument which was failing with cmake. cmake uses arguments like "-D<arg_name>=<value>".