### PR TITLE
MobileInsight v6.0 release

### DIFF
--- a/dm_collector_c/consts.h
+++ b/dm_collector_c/consts.h
@@ -131,7 +131,6 @@ enum LogPacketType {
     //GNSS related
     GNSS_GPS_Measurement_Report= 0x1477,
     GNSS_Glonass_Measurement_Report=0x1480,
-    QMI_MCS_QCSI_PKT=0x1544,
     GNSS_BDS_Measurement_Report=0x1756,
     GNSS_GAL_Measurement_Report=0x1886,
 
@@ -140,53 +139,30 @@ enum LogPacketType {
     NR_NAS_SM5G_Plain_OTA_Outgoing_Msg = 0xB801,
 
     // 5G MM
-    NR_NAS_MM5G_Plain_OTA_Incoming_Msg = 0xB80A,
-    NR_NAS_MM5G_Plain_OTA_Outgoing_Msg = 0xB80B,
-    NR_NAS_MM5G_Service_Request = 0xB80D,
     NR_NAS_MM5G_State= 0xB80C,
 
     // 5G RRC
     NR_RRC_OTA_Packet = 0xB821,
-    NR_RRC_Serving_Cell_Info = 0xB823,
-    NR_RRC_Configuration_Info = 0xB825,
 
     // 5G PDCP
-    NR_PDCP_DL_Data_PDU = 0xB840,
     NR_PDCP_UL_Control_Pdu = 0xB861, 
 
     // 5G L2
     NR_L2_UL_TB = 0xB872,
     NR_L2_UL_BSR = 0xB873,
-    NR_L2_UL_Data_PDU = 0xB870,
 
     // 5G RLC
-    NR_RLC_UL_Stats = 0xB868,
-    NR_RLC_UL_Status_PDU = 0xB869,
-    NR_RLC_DL_Status_PDU = 0xB84E,
     NR_RLC_DL_Stats = 0xB84D,
 
     // 5G MAC
-    NR_MAC_UL_TB = 0xB880,
-    NR_MAC_UL_TB_Stats = 0xB881,
     NR_MAC_UL_Physical_Channel_Schedule_Report = 0xB883,
-    NR_MAC_DCI_Info = 0xB885,
-    NR_MAC_DL_TB_Report = 0xB886,
-    NR_MAC_PDSCH_Status = 0xB887,
     NR_MAC_PDSCH_Stats = 0xB888,
-    NR_MAC_RACH_Attempt = 0xB88A,
-    NR_MAC_CSF_Report = 0xB8A7,
-    NR_MAC_CDRX_Events_Info = 0xB890,
-    NR_MAC_UCI_Payload_Information = 0xB896,
-    
+    NR_MAC_RACH_Trigger= 0xB889,
+    NR_MAC_UL_TB_Stats=0xB881, 
     // 5G LL1/ML1
-    NR_LL1_FW_TX_IU_RF = 0xB8D1,
     NR_LL1_FW_Serving_FTL = 0xB8DD,
-    NR_LL1_FW_CSF_Reports = 0xB8E2,
-    NR_ML1_DL_Handover = 0xB952,
-    NR_ML1_Searcher_ACQ_Config_And_Response = 0xB96D,
-    NR_ML1_Searcher_Conn_Eval = 0xB96F,
+    NR_ML1_Searcher_Measurement_Database_Update_Ext = 0xB97F,                                       
     NR_ML1_Serving_Cell_Beam_Management = 0xB975,
-    NR_ML1_Searcher_Measurement_Database_Update_Ext = 0xB97F,
 
 };
 
@@ -401,26 +377,14 @@ const ValueName LogPacketTypeID_To_Name [] = {
         "5G_NR_NAS_SM_Plain_OTA_Outgoing_Msg", true},
 
 
-    {NR_NAS_MM5G_Plain_OTA_Incoming_Msg,
-        "5G_NR_NAS_MM_Plain_OTA_Incoming_Msg", true},
-    {NR_NAS_MM5G_Plain_OTA_Outgoing_Msg,
-        "5G_NR_NAS_MM_Plain_OTA_Outgoing_Msg", true},
-    {NR_NAS_MM5G_Service_Request,
-        "5G_NR_NAS_MM_Service_Request", true},
     {NR_NAS_MM5G_State,
         "5G_NR_NAS_MM5G_State",true},
 
 
     {NR_RRC_OTA_Packet,
         "5G_NR_RRC_OTA_Packet", true},
-    {NR_RRC_Serving_Cell_Info,
-        "5G_NR_RRC_Serving_Cell_Info", true},
-    {NR_RRC_Configuration_Info,
-        "5G_NR_RRC_Configuration_Info", true},
 
 
-    {NR_PDCP_DL_Data_PDU,
-        "5G_NR_PDCP_DL_Data_PDU", true},
     {NR_PDCP_UL_Control_Pdu,
         "5G_NR_PDCP_UL_Control_Pdu", true},
 
@@ -428,58 +392,25 @@ const ValueName LogPacketTypeID_To_Name [] = {
         "5G_NR_L2_UL_TB", true},
     {NR_L2_UL_BSR,
         "5G_NR_L2_UL_BSR", true},
-    {NR_L2_UL_Data_PDU,
-        "5G_NR_L2_UL_Data_PDU", true},
 
-    {NR_RLC_UL_Stats,
-        "5G_NR_RLC_UL_Stats", true},
-    {NR_RLC_UL_Status_PDU,
-        "5G_NR_RLC_UL_Status_PDU", true},
-    {NR_RLC_DL_Status_PDU,
-        "5G_NR_RLC_DL_Status_PDU", true},
     {NR_RLC_DL_Stats,
         "5G_NR_RLC_DL_Stats", true},
 
-    {NR_MAC_UL_TB,
-        "5G_NR_MAC_UL_TB", true},
     {NR_MAC_UL_TB_Stats,
         "5G_NR_MAC_UL_TB_Stats", true},
     {NR_MAC_UL_Physical_Channel_Schedule_Report,
         "5G_NR_MAC_UL_Physical_Channel_Schedule_Report", true},
-    {NR_MAC_DCI_Info,
-        "5G_NR_MAC_DCI_Info", true},
-    {NR_MAC_DL_TB_Report,
-        "5G_NR_MAC_DL_TB_Report", true},
-    {NR_MAC_PDSCH_Status,
-        "5G_NR_MAC_PDSCH_Status", true},
     {NR_MAC_PDSCH_Stats,
         "5G_NR_MAC_PDSCH_Stats", true},
-    {NR_MAC_RACH_Attempt,
-        "5G_NR_MAC_RACH_Attempt", true},
-    {NR_MAC_CSF_Report,
-        "5G_NR_MAC_CSF_Report", true},
-    {NR_MAC_CDRX_Events_Info,
-        "5G_NR_MAC_CDRX_Events_Info", true},
-    {NR_MAC_UCI_Payload_Information,
-        "5G_NR_MAC_UCI_Payload_Information", true},
+    {NR_MAC_RACH_Trigger,
+        "5G_NR_MAC_RACH_Trigger",true},
 
-    {NR_LL1_FW_TX_IU_RF,
-        "5G_NR_LL1_FW_TX_IU_RF", true},
     {NR_LL1_FW_Serving_FTL,
         "5G_NR_LL1_FW_Serving_FTL", true},
-    {NR_LL1_FW_CSF_Reports,
-        "5G_NR_LL1_FW_CSF_Reports", true},
-    {NR_ML1_DL_Handover,
-        "5G_NR_ML1_DL_Handover", true},
-    {NR_ML1_Searcher_ACQ_Config_And_Response,
-        "5G_NR_ML1_Searcher_ACQ_Config_And_Response", true},
-    {NR_ML1_Searcher_Conn_Eval,
-        "5G_NR_ML1_Searcher_Conn_Eval", true},
-    {NR_ML1_Serving_Cell_Beam_Management,
-        "5G_NR_ML1_Serving_Cell_Beam_Management", true},
-    {NR_ML1_Searcher_Measurement_Database_Update_Ext,
-        "5G_NR_ML1_Searcher_Measurement_Database_Update_Ext", true},
-
+    {NR_ML1_Searcher_Measurement_Database_Update_Ext,                                              
+        "5G_NR_ML1_Searcher_Measurement_Database_Update_Ext", true },
+    { NR_ML1_Serving_Cell_Beam_Management,
+        "5G_NR_ML1_Serving_Cell_Beam_Management", true },
 
 
     {Modem_debug_message,
@@ -488,10 +419,6 @@ const ValueName LogPacketTypeID_To_Name [] = {
         "GNSS_GPS_Measurement_Report", true},
     {GNSS_Glonass_Measurement_Report,
         "GNSS_Glonass_Measurement_Report", true},
-        
-    {QMI_MCS_QCSI_PKT,
-        "QMI_MCS_QCSI_PKT", false},
-        
     {GNSS_BDS_Measurement_Report,
         "GNSS_BDS_Measurement_Report", true},   
     {GNSS_GAL_Measurement_Report,

--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -11619,8 +11619,8 @@ on_demand_decode (const char *b, size_t length, LogPacketType type_id, PyObject*
     switch (type_id) {
 
         case NR_L2_UL_TB:
-            offset += _decode_by_fmt(NrL2UlTbFmt,
-                                     ARRAY_SIZE(NrL2UlTbFmt, Fmt),
+            offset += _decode_by_fmt(NrL2UlTb_Fmt,
+                                     ARRAY_SIZE(NrL2UlTb_Fmt, Fmt),
                                      b, offset, length, result);
 
             offset += _decode_nr_l2_ul_tb_subpkt(b, offset, length, result);

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -461,7 +461,6 @@ const ValueName NrRrcOtaPduType_v8[] = {
         // {0x00, "nr-rrc.ue_mrdc_cap"}, // unknown so far
         // {0x00, "nr-rrc.ue_nr_cap"}, // unknown so far
 };
-
 const ValueName NrRrcOtaPduType_v9[] = {
 
         // {0x00, "nr-rrc.ue_radio_paging_info"}, // unknown so far
@@ -2110,6 +2109,22 @@ const Fmt LteMacULBufferStatusInternal_ULBufferStatusSubPacket_LCIDFmt_v24[] = {
         {PLACEHOLDER, "Total Bytes",            0},
 };
 
+const Fmt LteMacULBufferStatusInternal_ULBufferStatusSubPacket_SampleFmt_v5[] = {
+        {UINT,        "Sub FN",                2},
+        {PLACEHOLDER, "Sys FN",                0},
+        {UINT,        "Number of active LCID", 1}
+};
+
+const Fmt LteMacULBufferStatusInternal_ULBufferStatusSubPacket_LCIDFmt_v5[] = {
+        {UINT,        "Ld Id",                  1},
+        {UINT,        "Priority",               1},
+        {UINT,        "New Uncompressed Bytes", 4},
+        {UINT,        "New Compressed Bytes",   4},
+        {UINT,        "Retx bytes",             4},
+        {UINT,        "Ctrl bytes",             2},
+        {PLACEHOLDER, "Total Bytes",            0},
+};
+
 // ----------------------------------------------------------------------------
 // LTE_RLC_UL_Config_Log_Packet
 
@@ -2619,6 +2634,12 @@ const Fmt LteMacRachTrigger_RachConfigSubpktPayload_v5[] = {
         {UINT,        "PRACH Cfg R13 Present",            1},
 };
 
+const Fmt LteMacRachTrigger_RachConfigSubpktPayload_v6[] = {
+        {WCDMA_MEAS,  "Preamble initial power (dB)",      2},    // Note sure if it is correct
+        {UINT,        "Power ramping step (dB)",          1},
+        {UINT,        "Delta preamble Msg3",              2},
+};
+
 const Fmt LteMacRachTrigger_RachConfigSubpktPayload_rsrp_prach_list_size_v5[] = {
         {UINT, "RSRP Thresh PRACH List Size", 1},
 };
@@ -2643,14 +2664,30 @@ const Fmt LteMacRachTrigger_RachConfigSubpktPayload_prach_list_v5[] = {
         {UINT,"Prach Cfg Index",                1},
         {UINT,"RA RSP Win Size",                1},
 };
+const Fmt LteMacRachTrigger_RachConfigSubpktPayload_prach_list_v6[] = {
+        {UINT,"First Subcarrier",                 1},
+        {UINT,"Multitone Subcarrer",              1},
+        {UINT,"Last Subcarrier",                  1},
+        {UINT,"Max Preamble Tx Attempt Per CE",   1},
+        {UINT,"Contention Resol Timer",           4},
+};
 
 const Fmt LteMacRachTrigger_RachConfigSubpktPayload_hidden_prach_list_v5[] = {
         {BYTE_STREAM, "Hidden PRACH Param Ce", 7},
 };
 
+const Fmt LteMacRachTrigger_RachConfigSubpktPayload_hidden_prach_list_v6[] = {
+        {BYTE_STREAM, "Hidden Prach Param Ce", 8},
+};
+
 const Fmt LteMacRachTrigger_RachConfigSubpktPayload_prach_last_part[] = {
         {UINT, "Initial CE Level",      2},
         {UINT, "Preamble Trans Max CE", 2},
+};
+
+const Fmt LteMacRachTrigger_RachConfigSubpktPayload_prach_last_part_v6[] = {
+        {UINT, "Preamble Trans Max CE", 2},
+        {SKIP, NULL,                   1},
 };
 
 const Fmt LteMacRachTrigger_RachReasonSubpktPayload[] = {
@@ -2678,6 +2715,19 @@ const Fmt LteMacRachTrigger_RachReasonSubpktPayload_v2[] = {
         {UINT,        "Group chosen",           1},
         {UINT,        "Radio condn (dB)",       1},
         {BYTE_STREAM_LITTLE_ENDIAN, "CRNTI",    2},
+};
+
+const Fmt LteMacRachTrigger_RachReasonSubpktPayload_v3[] = {
+        {UINT,        "Rach reason",            1},
+        {PLACEHOLDER, "RACH Contention",        0},
+        {UINT, "Maching ID",                    6},
+        {UINT,        "Preamble",        0},
+        {BYTE_STREAM, "Preamble RA mask",       1},
+        {UINT,        "Msg3 size",              1},
+        {UINT,        "CE Level",               1},
+        {UINT,        "Radio condn (dB)",       1},
+        {BYTE_STREAM_LITTLE_ENDIAN, "CRNTI",    2},
+        {SKIP, NULL,                            1},
 };
 
 const ValueName LteMacRachTrigger_RachReasonSubpkt_RachReason[] = {
@@ -4220,6 +4270,11 @@ const ValueName ValueNameSearchSpaceType[] = {
         {2, "User"},
 };
 
+const ValueName ValueNameSubcarrierSpaceType[] = {
+        // 3 bits
+        {4, "15 kHz"},
+};
+
 const ValueName ValueNameRNTIType[] = {
         // 4 bits
         {0, "C-RNTI"},
@@ -4236,6 +4291,34 @@ const ValueName ValueNameNBIoT_RNTIType[] = {
         // 2 bits
         {0, "C-RNTI"},
         {2, "TC-RNTI"},
+};
+
+const ValueName ValueNameNB1_PDSCH_RNTIType[] = {
+        // 3 bits
+        {1, "C-RNTI"},       
+        {3, "RA-RNTI"},
+        {4, "TC-RNTI"},
+};
+
+const ValueName ValueNameNB1_Sum_Sys_Info_MeasBWType[] = {
+        // 4 bits
+        {0, "mbw6 RBs"},
+};
+
+const ValueName ValueNameNB1_GM_TX_Report_Subcarrier_Space_Type[] = {
+        // 3 bits
+        {4, "15 kHz"},
+};
+
+const ValueName ValueNameNPUSCHFormat_1_TX_Type[] = {
+        // 1 bits
+        {0,  ""},
+        {1,  "New Transmission"},
+};
+const ValueName ValueNameNPUSCHFormat[] = {
+        // 1 bits
+        {0,  "Format 1"},
+        {1,  "Format 2"},
 };
 const ValueName ValueNameDCIFormat[] = {
         // 4 bits
@@ -4624,6 +4707,15 @@ const ValueName ValueNameGSMSignalingMessageType[] = {
 const ValueName ValueNameDirection[] = {
         {0, "Uplink"},
         {1, "Downlink"},
+};
+
+const ValueName ValueNameGNSSBDSEngineType[] = {
+        {6,"GEN9"},
+};
+const ValueName ValueNameBdsObsState[]={
+        {1,"SRCH"},
+        {4,"TRK VER"},
+	{5,"TRK"}
 };
 
 // ----------------------------------------------------------------------------

--- a/dm_collector_c/log_packet_helper.h
+++ b/dm_collector_c/log_packet_helper.h
@@ -104,22 +104,23 @@ _search_result_int(PyObject *result, const char *target) {
 
     return val;
 }
+//adding
+// This function should be called when the value is 8 bytes long.
+// Return: unsigned long int
+static unsigned long int _search_result_ulongint(
+        PyObject *result,
+        const char *target)
+__attribute__ ((unused));
 
+static unsigned long int
+_search_result_ulongint(PyObject *result, const char *target) {
+    PyObject *item = _search_result(result, target);
+    assert(PyLong_Check(item));
+    unsigned long int val = (unsigned long int) PyLong_AsUnsignedLongLongMask(item);
+    Py_DECREF(item);
 
-static PyObject* _replace_result_string(
-    PyObject* result,
-    const char* target,
-    std::string new_string)
-    __attribute__((unused));
-
-static PyObject*
-_replace_result_string(PyObject* result, const char* target, std::string new_string) {
-    PyObject* pystring = Py_BuildValue("s", new_string.c_str());
-    PyObject* old_object = _replace_result(result, target, pystring);
-    Py_DECREF(pystring);
-    return old_object;
+    return val;
 }
-
 
 
 // This function should be called when the value is 4 bytes long.
@@ -139,23 +140,6 @@ _search_result_uint(PyObject *result, const char *target) {
     return val;
 }
 
-//adding
-// This function should be called when the value is 8 bytes long.
-// Return: unsigned long int
-static unsigned long int _search_result_ulongint(
-        PyObject *result,
-        const char *target)
-__attribute__ ((unused));
-
-static unsigned long int
-_search_result_ulongint(PyObject *result, const char *target) {
-    PyObject *item = _search_result(result, target);
-    assert(PyLong_Check(item));
-    unsigned long int val = (unsigned long int) PyLong_AsUnsignedLongLongMask(item);
-    Py_DECREF(item);
-
-    return val;
-}
 static const char*
 _search_result_bytestream(PyObject *result, const char *target) {
     PyObject *item = _search_result(result, target);
@@ -186,8 +170,6 @@ _replace_result(PyObject *result, const char *target, PyObject *new_object) {
     }
 }
 
-
-
 static void
 _delete_result(PyObject *result, const char *target){
     int i = _find_result_index(result, target);
@@ -209,6 +191,19 @@ _replace_result_int(PyObject *result, const char *target, int new_int) {
     PyObject *pyint = Py_BuildValue("i", new_int);
     PyObject *old_object = _replace_result(result, target, pyint);
     Py_DECREF(pyint);
+    return old_object;
+}
+static PyObject* _replace_result_string(
+    PyObject* result,
+    const char* target,
+    std::string new_string)
+    __attribute__((unused));
+
+static PyObject*
+_replace_result_string(PyObject* result, const char* target, std::string new_string) {
+    PyObject* pystring = Py_BuildValue("s", new_string.c_str());
+    PyObject* old_object = _replace_result(result, target, pystring);
+    Py_DECREF(pystring);
     return old_object;
 }
 
@@ -438,9 +433,6 @@ _decode_by_fmt(const Fmt fmt[], int n_fmt,
                 n_consumed += fmt[i].len;
                 break;
             }
-
-
-
             case PLMN_MK1: {
                 assert(fmt[i].len == 6);
                 const char *plmn = p;
@@ -597,5 +589,15 @@ _convert_nr_rsrq(PyObject *obj, const char *rsrq_field){
     Py_DECREF(old_object);
     Py_DECREF(pyfloat);
 }
+// static void reprint(PyObject *obj) {
+//     PyObject* repr = PyObject_Repr(obj);
+//     PyObject* str = PyUnicode_AsEncodedString(repr, "utf-8", "~E~");
+//     const char *bytes = PyBytes_AS_STRING(str);
+
+//     printf("REPR: %s\n", bytes);
+
+//     Py_XDECREF(repr);
+//     Py_XDECREF(str);
+// }
 
 #endif // __DM_COLLECTOR_C_LOG_PACKET_HELPER_H__

--- a/dm_collector_c/nr_ll1_fw_serving_ftl.h
+++ b/dm_collector_c/nr_ll1_fw_serving_ftl.h
@@ -109,8 +109,8 @@ static int _decode_nr_ll1_fw_serving_ftl_payload (const char *b,
     }	
     default:
         printf("(MI)Unknown NR5G LL1 FW Serving FTL version: %d\n", pkt_ver);
-        return 0;
     }
+    return 0;
 }				
 		
 		


### PR DESCRIPTION
MobileInsight 6.0 release
==========================

We are thrilled to announce the release of MobileInsight v5.0.0. The main updates include

- **5G:** MobileInsight now supports data collection of analytics of 5G. The first release supports the following messages:

  - NR NAS MM5G State
  - NR NAS SM5G Plain OTA Incoming
  - NR NAS SM5G Plain OTA Incoming
  - NR RRC OTA Packet
  - NR PDCP UL Control PDU
  - NR RLC DL Stats
  - NR MAC RACH Trigger
  - NR LL1 FW Serving FTL

  Moreover, this release offers analyzers for the runtime 5G RRC state, PHY/link-layer configurations, handover parameters/measurements/decisions, and dual connectivity analysis. 

- **Navigation satellites:** MobileInsight now supports data collection of analytics of popular Global Navigation Satellite Systems (GNSS), including GPS, Beidou, Glonass, and Galileo. The first release supports the following messages:

  - GNSS_GPS_Measurement_Report
  - GNSS_Glonass_Measurement_Report
  - GNSS_BDS_Measurement_Report
  - GNSS_GAL_Measurement_Report


- **Internet-of-Things (IoT):** Starting from this version, MobileInsight will also progressively support data collection and analytics of cellular IoT. The first release supports the following messages:

  - LTE_NB1_Random_Access_Request_Report
  - LTE_NB1_Random_Access_Response_Report
  - LTE_NB1_UE_Identification_Message_Report
  - LTE_NB1_Contention_Resolution_Message_Report
  - LTE_NB1_ML1_GM_DCI_Info
  - LTE_NB1_ML1_GM_TX_Report
  - LTE_NB1_ML1_GM_PDSCH_STAT_Ind
  - LTE_NB1_ML1_CDRX_Events_Info
  - LTE_NB1_ML1_Sum_Sys_Info
  - LTE_NB1_ML1_Cell_Resel
  - LTE_NB1_ML1_Serv_Cell_Meas_Response
  - LTE_NB1_NBR_Cell_Meas
  - LTE_NB1_ML1_Search_PBCH_Decode
  - LTE_NB1_ML1_DLM_Decode_Page

- **Updated 4G LTE control-plane analytics for 5G:** For incremental deployment, most operational 5G networks so far adopt the non-standalone (NSA) and dual connectivity mode that use 4G LTE's core network and radio access as the "anchor". To this end, MobileInsight also updates its 4G LTE analyzers to tackle both modes. The latest LTE RRC analyzer now can analyze the 4G<->5G handovers and dual connectivity. 