### PR TITLE
LTE bandwidth predictor fix

### DIFF
--- a/mobile_insight/analyzer/analyzer.py
+++ b/mobile_insight/analyzer/analyzer.py
@@ -225,9 +225,6 @@ class Analyzer(Element):
         # A lambda function: input as a callback, output as passing event to
         # this callback
 
-        if not event.data:
-            return
-
         if module == self.source:
             # Apply the event to all source callbacks
             for i in range(len(self.source_callback)):

--- a/mobile_insight/analyzer/kpi/lte_bandwidth_predictor.py
+++ b/mobile_insight/analyzer/kpi/lte_bandwidth_predictor.py
@@ -305,14 +305,14 @@ class LteBandwidthPredictor(KpiAnalyzer):
                     msgtimestamp = str(log_item['timestamp'])
 
                     self.array_nRB_pcell.sort()
-                    nRB_allocated = self.array_nRB_pcell[len(self.array_nRB_pcell) / 2]
+                    nRB_allocated = self.array_nRB_pcell[len(self.array_nRB_pcell) // 2]
                     self.array_MCS_pcell.sort()
-                    MCS_result = self.array_MCS_pcell[len(self.array_MCS_pcell) / 2]
+                    MCS_result = self.array_MCS_pcell[len(self.array_MCS_pcell) // 2]
 
                     self.array_cqi_pcell.sort()
-                    cqi = self.array_cqi_pcell[len(self.array_cqi_pcell) / 2]
+                    cqi = self.array_cqi_pcell[len(self.array_cqi_pcell) // 2]
                     self.array_ri_pcell.sort()
-                    ri = self.array_ri_pcell[len(self.array_ri_pcell) / 2]
+                    ri = self.array_ri_pcell[len(self.array_ri_pcell) // 2]
 
                     if len(self.array_data_frame_pcell) > 0:
                         for sys_fn, sub_fn in self.array_data_frame_pcell:
@@ -330,9 +330,9 @@ class LteBandwidthPredictor(KpiAnalyzer):
                         readyForEstimate = False
                     if readyForEstimate:
                         self.array_rsrq_pcell.sort()
-                        rsrq = self.array_rsrq_pcell[len(self.array_rsrq_pcell) / 2]
+                        rsrq = self.array_rsrq_pcell[len(self.array_rsrq_pcell) // 2]
                         self.array_snr_pcell.sort()
-                        snr = self.array_snr_pcell[len(self.array_snr_pcell) / 2]
+                        snr = self.array_snr_pcell[len(self.array_snr_pcell) // 2]
 
                         estimated_bandwidth, nRB_new, MCS_new, cell_load = self.predict_bandwidth(\
                                 rsrq, \


### PR DESCRIPTION
This fix make `LTE bandwidth predictor` works.

What changed:
- `LteBandwidthPredictor` waits for event from `TrackCellInfoAnalyzer`, but the event is dropped by `Analyzer` base class because it contains `None` in `data` field:

`TrackCellInfoAnalyzer` notifier method: 

```python
    def __callback_mib_cell(self, msg):
        self.__mib_antenna = msg.data['Number of Antenna']
        self.__mib_dl_bandwidth = msg.data['DL BW']
        self.__mib_cell_id = msg.data['Physical Cell ID']
        self.__mib_freq = msg.data['Freq']
        event = Event(None, 'MIB_CELL', None)   # sends event with
        self.send(event)                        # 'None' in data field
```
Event is filtered in `Analyzer` base method:

```python
    def recv(self, module, event):
        ...
        if not event.data:  # the event is dropped here
            return
        ...
```

In result the `LteBandwidthPredictor` never starts.

- Fixed arrays indices calculations in `LteBandwidthPredictor` itself. The previous version may create float indices what  leads to crash.