### PR TITLE
Support timestamp filtering and byte object as input/output

### DIFF
--- a/dm_collector_c/dm_collector_c.cpp
+++ b/dm_collector_c/dm_collector_c.cpp
@@ -715,7 +715,7 @@ dm_collector_c_receive_log_packet(PyObject *self, PyObject *args) {
                                                       frame.size() - 2,
                                                       skip_decoding);
                 if (include_timestamp) {
-                        PyObject *ret = Py_BuildValue("(Od)", decoded, posix_timestamp);
+                        PyObject *ret = Py_BuildValue("(Ody#)", decoded, posix_timestamp, g_emanager.log_object.c_str(), g_emanager.log_object.size());
 
                     if(decoded != Py_None)
                             Py_DECREF(decoded);

--- a/dm_collector_c/export_manager.cpp
+++ b/dm_collector_c/export_manager.cpp
@@ -64,6 +64,7 @@ manager_init_state (struct ExportManagerState *pstate) {
     pstate->whitelist.clear();
     pstate->start_timestamp = 0.0;
     pstate->end_timestamp = DBL_MAX;
+    pstate->log_object = "";
     return;
 }
 
@@ -75,10 +76,11 @@ manager_export_binary (struct ExportManagerState *pstate, const char *b, size_t 
 
     if (pstate->whitelist.count(type_id) > 0 && 
         packet_timestamp >= pstate->start_timestamp &&
-        packet_timestamp <= pstate->end_timestamp) { // filter
+        packet_timestamp <= pstate->end_timestamp) { // filter 
 
         if (pstate->log_fp != NULL) {
             std::string frame = encode_hdlc_frame(b, (int) length);
+            pstate->log_object = frame;
             size_t cnt = fwrite(frame.c_str(), sizeof(char), frame.size(), pstate->log_fp);
             (void)cnt;
         }

--- a/dm_collector_c/export_manager.cpp
+++ b/dm_collector_c/export_manager.cpp
@@ -78,9 +78,9 @@ manager_export_binary (struct ExportManagerState *pstate, const char *b, size_t 
         packet_timestamp >= pstate->start_timestamp &&
         packet_timestamp <= pstate->end_timestamp) { // filter 
 
+        std::string frame = encode_hdlc_frame(b, (int) length);
+        pstate->log_object = frame;
         if (pstate->log_fp != NULL) {
-            std::string frame = encode_hdlc_frame(b, (int) length);
-            pstate->log_object = frame;
             size_t cnt = fwrite(frame.c_str(), sizeof(char), frame.size(), pstate->log_fp);
             (void)cnt;
         }

--- a/dm_collector_c/export_manager.cpp
+++ b/dm_collector_c/export_manager.cpp
@@ -13,18 +13,46 @@
 #include "hdlc.h"
 #include "log_packet.h"
 #include "log_packet_helper.h"
+#include <cfloat>
+#include <cstring>
+#include <iostream>
 
-// A simple but dirty function to retrieve type ID.
+const double PER_SECOND = 52428800.0;
+const double PER_USECOND = 52428800.0 / 1.0e6;
+const time_t BASE_TIMESTAMP = 315993600; // Param for parsing raw timestamp into UNIX timestamp
+
+uint64_t
+get_timestamp(const char *b, size_t offset) {
+    uint64_t timestamp = 0;
+    std::memcpy(&timestamp, b + offset, sizeof(uint64_t));
+    return timestamp;
+}
+
+double
+convert_to_unix(uint64_t packet_timestamp) {
+    int seconds = int(double(packet_timestamp) / PER_SECOND);
+    int useconds = (double(packet_timestamp) / PER_USECOND) - double(seconds) * 1.0e6;
+    return BASE_TIMESTAMP + seconds + useconds / 1.0e6;
+}
+
+// A simple but dirty function to retrieve type ID and timestamp.
 // Return -1 if the packet is not recognized
 static int
-get_log_type(const char *b, size_t length) {
+get_log_type_and_timestamp(const char *b, size_t length, double &packet_timestamp) {
     int type_id = -1;
+    unsigned long int timestamp = 0;
     if (is_log_packet(b, length) && length >= 8) {
         // 8 = 2 (0x1000) + 2 (len1) + 2 (log_msg_len) + 2 (type_id)
         short t = *((unsigned short *)(b + 6));
         type_id = ((int) t) & 0xFFFF;
+
+        timestamp = get_timestamp(b, 8);
+        packet_timestamp = convert_to_unix(timestamp);
+
     } else if (is_debug_packet(b, length)) {
         type_id = Modem_debug_message;
+        timestamp = get_timestamp(b, 8);
+        packet_timestamp = convert_to_unix(timestamp);
     }
     return type_id;
 }
@@ -34,14 +62,20 @@ manager_init_state (struct ExportManagerState *pstate) {
     pstate->log_fp = NULL;
     pstate->filename = "";
     pstate->whitelist.clear();
+    pstate->start_timestamp = 0.0;
+    pstate->end_timestamp = DBL_MAX;
     return;
 }
 
 bool
 manager_export_binary (struct ExportManagerState *pstate, const char *b, size_t length) {
 
-    int type_id = get_log_type(b, length);
-    if (pstate->whitelist.count(type_id) > 0) { // filter
+    double packet_timestamp = 0.0;
+    int type_id = get_log_type_and_timestamp(b, length, packet_timestamp);
+
+    if (pstate->whitelist.count(type_id) > 0 && 
+        packet_timestamp >= pstate->start_timestamp &&
+        packet_timestamp <= pstate->end_timestamp) { // filter
 
         if (pstate->log_fp != NULL) {
             std::string frame = encode_hdlc_frame(b, (int) length);
@@ -68,4 +102,12 @@ manager_change_config (struct ExportManagerState *pstate,
     }
     pstate->whitelist.clear();
     pstate->whitelist.insert(whitelist.begin(), whitelist.end());
+}
+
+void 
+manager_set_filter(ExportManagerState *pstate, const IdVector &whitelist, double start_timestamp, double end_timestamp) {
+    pstate->whitelist.clear();
+    pstate->whitelist.insert(whitelist.begin(), whitelist.end());
+    pstate->start_timestamp = start_timestamp;
+    pstate->end_timestamp = end_timestamp;
 }

--- a/dm_collector_c/export_manager.cpp
+++ b/dm_collector_c/export_manager.cpp
@@ -19,7 +19,7 @@
 
 const double PER_SECOND = 52428800.0;
 const double PER_USECOND = 52428800.0 / 1.0e6;
-const time_t BASE_TIMESTAMP = 315993600; // Param for parsing raw timestamp into UNIX timestamp
+const time_t BASE_TIMESTAMP = 315964800; // Param for parsing raw timestamp into UNIX timestamp
 
 uint64_t
 get_timestamp(const char *b, size_t offset) {

--- a/dm_collector_c/export_manager.h
+++ b/dm_collector_c/export_manager.h
@@ -12,13 +12,15 @@ struct ExportManagerState {
     FILE *log_fp;   // Point to the current log.
     std::string filename;
     std::set<int> whitelist;
+    double start_timestamp;
+    double end_timestamp;
 };
 
 // Must be called before usage
 void manager_init_state (struct ExportManagerState *pstate);
 void manager_change_config (struct ExportManagerState *pstate,
                             const char *new_path, const IdVector &whitelist);
-
+void manager_set_filter(ExportManagerState *pstate, const IdVector &whitelist, double start_timestamp, double end_timestamp);
 // Export raw msgs that are in the whitelist
 bool manager_export_binary (struct ExportManagerState *pstate, const char *b, size_t length);
 

--- a/dm_collector_c/export_manager.h
+++ b/dm_collector_c/export_manager.h
@@ -14,6 +14,7 @@ struct ExportManagerState {
     std::set<int> whitelist;
     double start_timestamp;
     double end_timestamp;
+    std::string log_object;
 };
 
 // Must be called before usage

--- a/examples/offline-analysis-filtering.py
+++ b/examples/offline-analysis-filtering.py
@@ -2,6 +2,7 @@
 # Filename: offline-analysis-filtering.py
 import os
 import sys
+from datetime import datetime
 
 """
 Offline analysis: save the log as a new one with pre-defined filter
@@ -17,6 +18,9 @@ if __name__ == "__main__":
     src.set_input_path("./offline_log_example.mi2log")
 
     # Configure the log to be saved
+    start_timestamp = datetime(2020, 11, 16, 9, 49, 0)
+    end_timestamp = datetime(2020, 11, 16, 9, 50, 0)
+    src.enable_log("LTE_RRC_OTA_Packet", start_timestamp, end_timestamp)
     src.enable_log("LTE_NAS_ESM_OTA_Incoming_Packet")
     src.enable_log("LTE_RRC_Serv_Cell_Info")
     src.enable_log("LTE_RRC_OTA_Packet")

--- a/mobile_insight/monitor/dm_collector/dm_collector.py
+++ b/mobile_insight/monitor/dm_collector/dm_collector.py
@@ -74,7 +74,7 @@ class DMCollector(Monitor):
         """
         self.phy_baudrate = rate
 
-    def enable_log(self, type_name):
+    def enable_log(self, type_name, start_timestamp = None, end_timestamp = None):
         """
         Enable the messages to be monitored.
         Currently DMCollector supports the following logs:
@@ -93,14 +93,18 @@ class DMCollector(Monitor):
             if n not in self._type_names:
                 self._type_names.append(n)
                 self.log_info("Enable collection: " + n)
-        dm_collector_c.set_filtered(self._type_names)
 
-    def enable_log_all(self):
+        start_timestamp = start_timestamp.timestamp() if start_timestamp else 0.0
+        end_timestamp = end_timestamp.timestamp() if end_timestamp else float('Inf')
+
+        dm_collector_c.set_filtered(self._type_names, start_timestamp, end_timestamp)
+
+    def enable_log_all(self, start_timestamp = None, end_timestamp = None):
         """
         Enable all supported logs
         """
         cls = self.__class__
-        self.enable_log(cls.SUPPORTED_TYPES)
+        self.enable_log(cls.SUPPORTED_TYPES, start_timestamp, end_timestamp)
 
     def save_log_as(self, path):
         """

--- a/mobile_insight/monitor/offline_replayer.py
+++ b/mobile_insight/monitor/offline_replayer.py
@@ -100,7 +100,7 @@ class OfflineReplayer(Monitor):
     def set_sampling_rate(self, sampling_rate):
         dm_collector_c.set_sampling_rate(sampling_rate)
 
-    def enable_log(self, type_name):
+    def enable_log(self, type_name, start_timestamp = None, end_timestamp = None):
         """
         Enable the messages to be monitored. Refer to cls.SUPPORTED_TYPES for supported types.
 
@@ -120,14 +120,18 @@ class OfflineReplayer(Monitor):
             if n not in self._type_names:
                 self._type_names.append(n)
                 self.log_info("Enable " + n)
-        dm_collector_c.set_filtered(self._type_names)
 
-    def enable_log_all(self):
+        start_timestamp = start_timestamp.timestamp() if start_timestamp else 0.0
+        end_timestamp = end_timestamp.timestamp() if end_timestamp else float('Inf')
+
+        dm_collector_c.set_filtered(self._type_names, start_timestamp, end_timestamp)
+
+    def enable_log_all(self, start_timestamp = None, end_timestamp = None):
         """
         Enable all supported logs
         """
         cls = self.__class__
-        self.enable_log(cls.SUPPORTED_TYPES)
+        self.enable_log(cls.SUPPORTED_TYPES, start_timestamp, end_timestamp)
 
     def set_input_path(self, path):
         """


### PR DESCRIPTION
This request contains two commits:

1. Support timestamp filtering in mi2log file. Users now can pass in `start_timesetamp` and `end_timestamp` to `OfflineReplayer` so that it only contains logs within the start-end interval.
2. Support byte object as input/output. For input part, I add a function `set_input_file(object)` in `OfflineReplayer` for users to pass in byte object directly. For output part, users can access the byte object via `OfflineReplayer.output_bytes_object`.