### PR TITLE
fix: Python 3.12 compatibility and LTE RRC OTA v27 support

### DIFF
--- a/dm_collector_c/dm_collector_c.cpp
+++ b/dm_collector_c/dm_collector_c.cpp
@@ -5,6 +5,7 @@
  * and decodes diagnositic logs from Qualcomm chipsets.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "consts.h"
@@ -627,7 +628,7 @@ static PyObject *
 dm_collector_c_feed_binary(PyObject *self, PyObject *args) {
     (void) self;
     const char *b;
-    int length;
+    Py_ssize_t length;
     if (!PyArg_ParseTuple(args, "y#", &b, &length)) {
          printf("dm_collector_c_feed_binary returns NULL\n");
         return NULL;

--- a/dm_collector_c/export_manager.cpp
+++ b/dm_collector_c/export_manager.cpp
@@ -5,6 +5,7 @@
  * we can merge them in the future.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "consts.h"

--- a/dm_collector_c/hdlc.cpp
+++ b/dm_collector_c/hdlc.cpp
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "hdlc.h"

--- a/dm_collector_c/log_config.cpp
+++ b/dm_collector_c/log_config.cpp
@@ -2,6 +2,7 @@
  * Author: Jiayao Li
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "consts.h"

--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -3,6 +3,7 @@
  * Implements log packet message decoding.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <datetime.h>
 #include <fstream>
@@ -173,7 +174,7 @@ _decode_wcdma_signaling_messages(const char *b, int offset, size_t length,
     std::string type_str = "raw_msg/";
     type_str += ch_name;
     PyObject *t = Py_BuildValue("(sy#s)",
-                                "Msg", b + offset, pdu_length, type_str.c_str());
+                                "Msg", b + offset, (Py_ssize_t)pdu_length, type_str.c_str());
     PyList_Append(result, t);
     Py_DECREF(t);
     return offset - start;
@@ -240,7 +241,7 @@ _decode_umts_nas_ota(const char *b, int offset, size_t length,
 
     int pdu_length = _search_result_int(result, "Message Length");
     PyObject *t = Py_BuildValue("(sy#s)",
-                                "Msg", b + offset, pdu_length,
+                                "Msg", b + offset, (Py_ssize_t)pdu_length,
                                 "raw_msg/NAS");
     PyList_Append(result, t);
     Py_DECREF(t);
@@ -314,13 +315,18 @@ _decode_lte_rrc_ota(const char *b, int offset, size_t length,
                                      ARRAY_SIZE(LteRrcOtaPacketFmt_v26, Fmt),
                                      b, offset, length, result);
             break;
+        case 27:
+            offset += _decode_by_fmt(LteRrcOtaPacketFmt_v27,
+                                     ARRAY_SIZE(LteRrcOtaPacketFmt_v27, Fmt),
+                                     b, offset, length, result);
+            break;
         default:
             printf("(MI)Unknown LTE RRC OTA packet version: %d\n", pkt_ver);
             return 0;
     }
 
     //pkt_ver == 26 added for
-    if(pkt_ver == 19 || pkt_ver == 26) {
+    if(pkt_ver == 19 || pkt_ver == 26 || pkt_ver == 27) {
 
         int pdu_number = _search_result_int(result, "PDU Number");
         int pdu_length = _search_result_int(result, "Msg Length");
@@ -336,9 +342,13 @@ _decode_lte_rrc_ota(const char *b, int offset, size_t length,
             std::string type_str = "raw_msg/";
             type_str += type_name;
             PyObject *t = Py_BuildValue("(sy#s)",
-                                        "Msg", b + offset, pdu_length, type_str.c_str());
+                                        "Msg", b + offset, (Py_ssize_t)pdu_length, type_str.c_str());
+            if (t == NULL) {
+                printf("(MI)ERROR: Py_BuildValue returned NULL for pkt_ver=%d, pdu_length=%d, offset=%d, type=%s\n", pkt_ver, pdu_length, offset, type_name);
+                if (PyErr_Occurred()) PyErr_Print();
+            }
             PyList_Append(result, t);
-            Py_DECREF(t);
+            Py_XDECREF(t);
             return (offset - start) + pdu_length;
         }
 
@@ -358,7 +368,7 @@ _decode_lte_rrc_ota(const char *b, int offset, size_t length,
             std::string type_str = "raw_msg/";
             type_str += type_name;
             PyObject *t = Py_BuildValue("(sy#s)",
-                                        "Msg", b + offset, pdu_length, type_str.c_str());
+                                        "Msg", b + offset, (Py_ssize_t)pdu_length, type_str.c_str());
             PyList_Append(result, t);
             Py_DECREF(t);
             return (offset - start) + pdu_length;
@@ -380,7 +390,7 @@ _decode_lte_rrc_ota(const char *b, int offset, size_t length,
             std::string type_str = "raw_msg/";
             type_str += type_name;
             PyObject *t = Py_BuildValue("(sy#s)",
-                                        "Msg", b + offset, pdu_length, type_str.c_str());
+                                        "Msg", b + offset, (Py_ssize_t)pdu_length, type_str.c_str());
             PyList_Append(result, t);
             Py_DECREF(t);
             return (offset - start) + pdu_length;
@@ -11411,11 +11421,11 @@ _decode_nr_rrc_ota(const char *b, int offset, size_t length,
                 // RRC Reconfiguration Complete needs special processing
                 char *ul_dcch_msg = _nr_rrc_reconf_complete_to_ul_dcch(b + offset, pdu_length);
                 t = Py_BuildValue("(sy#s)",
-                                  "Msg", ul_dcch_msg, pdu_length + 1, type_str.c_str());
+                                  "Msg", ul_dcch_msg, (Py_ssize_t)(pdu_length + 1), type_str.c_str());
                 delete ul_dcch_msg;
             } else {
                 t = Py_BuildValue("(sy#s)",
-                                  "Msg", b + offset, pdu_length, type_str.c_str());
+                                  "Msg", b + offset, (Py_ssize_t)pdu_length, type_str.c_str());
             }
             PyList_Append(result, t);
             Py_DECREF(t);
@@ -11441,11 +11451,11 @@ _decode_nr_rrc_ota(const char *b, int offset, size_t length,
                 // RRC Reconfiguration Complete needs special processing
                 char *ul_dcch_msg = _nr_rrc_reconf_complete_to_ul_dcch(b + offset, pdu_length);
                 t = Py_BuildValue("(sy#s)",
-                                  "Msg", ul_dcch_msg, pdu_length + 1, type_str.c_str());
+                                  "Msg", ul_dcch_msg, (Py_ssize_t)(pdu_length + 1), type_str.c_str());
                 delete ul_dcch_msg;
             } else {
                 t = Py_BuildValue("(sy#s)",
-                                  "Msg", b + offset, pdu_length, type_str.c_str());
+                                  "Msg", b + offset, (Py_ssize_t)pdu_length, type_str.c_str());
             }
             PyList_Append(result, t);
             Py_DECREF(t);
@@ -11477,12 +11487,12 @@ _decode_nr_rrc_ota(const char *b, int offset, size_t length,
                 // RRC Reconfiguration Complete needs special processing
                 char* ul_dcch_msg = _nr_rrc_reconf_complete_to_ul_dcch(b + offset, pdu_length);
                 t = Py_BuildValue("(sy#s)",
-                    "Msg", ul_dcch_msg, pdu_length + 1, type_str.c_str());
+                    "Msg", ul_dcch_msg, (Py_ssize_t)(pdu_length + 1), type_str.c_str());
                 delete ul_dcch_msg;
             }
             else {
                 t = Py_BuildValue("(sy#s)",
-                    "Msg", b + offset, pdu_length, type_str.c_str());
+                    "Msg", b + offset, (Py_ssize_t)pdu_length, type_str.c_str());
             }
             PyList_Append(result, t);
             Py_DECREF(t);
@@ -12390,7 +12400,7 @@ decode_custom_packet (const char *b, size_t length) {
 void
 decode_custom_packet_payload (const char *b, size_t length, PyObject* result)
 {
-    PyObject *pystr = Py_BuildValue("s#", b, length);
+    PyObject *pystr = Py_BuildValue("s#", b, (Py_ssize_t)length);
     PyObject *old_object = _replace_result(result, "Msg", pystr);
     Py_DECREF(old_object);
     Py_DECREF(pystr);

--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -4124,7 +4124,8 @@ _decode_lte_mac_ul_transportblock_subpkt(const char *b, int offset, size_t lengt
     int n_subpkt = _search_result_int(result, "Num SubPkt");
 
     switch (pkt_ver) {
-        case 1: {
+        case 1:
+        case 0x30: {
             PyObject *result_allpkts = PyList_New(0);
             for (int i = 0; i < n_subpkt; i++) {
                 PyObject *result_subpkt = PyList_New(0);
@@ -4154,7 +4155,8 @@ _decode_lte_mac_ul_transportblock_subpkt(const char *b, int offset, size_t lengt
                     bool success = false;
                     PyObject *result_sample_list = PyList_New(0);
                     switch (subpkt_ver) {
-                        case 1: {
+                        case 1:
+                        case 3: {
                             // UL Transport Block Subpacket V1
                             for (int j = 0; j < subpkt_nsample; j++) {
                                 PyObject *result_subpkt_sample = PyList_New(0);
@@ -4863,7 +4865,8 @@ _decode_lte_mac_dl_transportblock_subpkt(const char *b, int offset, size_t lengt
     int n_subpkt = _search_result_int(result, "Num SubPkt");
 
     switch (pkt_ver) {
-        case 1: {
+        case 1:
+        case 0x32: {
             PyObject *result_allpkts = PyList_New(0);
             for (int i = 0; i < n_subpkt; i++) {
                 PyObject *result_subpkt = PyList_New(0);
@@ -5348,7 +5351,8 @@ _decode_lte_mac_ul_bufferstatusinternal_subpkt(const char *b, int offset, size_t
 
     PyObject *old_object;
     switch (pkt_ver) {
-        case 1: {
+        case 1:
+        case 0x30: {
             PyObject *result_allpkts = PyList_New(0);
             for (int i = 0; i < n_subpkt; i++) {
                 PyObject *result_subpkt = PyList_New(0);
@@ -5375,8 +5379,10 @@ _decode_lte_mac_ul_bufferstatusinternal_subpkt(const char *b, int offset, size_t
                 } else {
                     bool success = false;
                     switch (subpkt_ver) {
-                        case 3: {
-                            // UL Buffer Status SubPacket v3
+                        case 1:
+                        case 3:
+                        case 4: {
+                            // UL Buffer Status SubPacket v1/v3/v4
                             PyObject *result_subpkt_allsamples = PyList_New(0);
 
                             for (int j = 0; j < subpkt_nsample; j++) {
@@ -5552,7 +5558,8 @@ _decode_lte_mac_ul_txstatistics_subpkt(const char *b, int offset, size_t length,
     int n_subpkt = _search_result_int(result, "Num SubPkt");
 
     switch (pkt_ver) {
-        case 1: {
+        case 1:
+        case 0x30: {
             PyObject *result_allpkts = PyList_New(0);
             for (int i = 0; i < n_subpkt; i++) {
                 PyObject *result_subpkt = PyList_New(0);
@@ -12369,6 +12376,12 @@ decode_log_packet(const char *b, size_t length, bool skip_decoding) {
 
     on_demand_decode(b + offset, length - offset, type_id, result);
 
+    PyObject *t_raw = Py_BuildValue("(sy#s)", "Raw Msg", b, length, "bytearray");
+    if (t_raw) {
+        PyList_Append(result, t_raw);
+        Py_DECREF(t_raw);
+    }
+
     return result;
 }
 
@@ -12540,6 +12553,11 @@ decode_log_packet_modem(const char *b, size_t length, bool skip_decoding) {
             break;
     };
 
+    PyObject *t_raw = Py_BuildValue("(sy#s)", "Raw Msg", b, length, "bytearray");
+    if (t_raw) {
+        PyList_Append(result, t_raw);
+        Py_DECREF(t_raw);
+    }
 
     return result;
 }

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -373,6 +373,20 @@ const Fmt LteRrcOtaPacketFmt_v26[] = {
         {UINT, "Msg Length",                  2}
 };
 
+const Fmt LteRrcOtaPacketFmt_v27[] = {
+        {BYTE_STREAM, "RRC Version Number",   1}, 
+        {UINT, "NR RRC Release Number",       1},
+        {BYTE_STREAM, "NR RRC Version Number",1},
+        {UINT, "Radio Bearer ID",             1},
+        {UINT, "Physical Cell ID",            2},    //Cell ID
+        {UINT, "Freq",                        2},    //frequency
+        {UINT, "SysFrameNum/SubFrameNum",     4},    //System/subsystem frame number 
+        {UINT, "PDU Number",                  1},    //PDU number
+        {UINT, "SIB Mask in SI",              1},
+        {SKIP, NULL,                          3},
+        {UINT, "Msg Length",                  2}
+};
+
 const ValueName LteRrcOtaPduType[] = {
         {0x02, "LTE-RRC_BCCH_DL_SCH"},
         {0x04, "LTE-RRC_PCCH"},

--- a/dm_collector_c/nr_nas_sm5g_plain_ota_incoming_msg.h
+++ b/dm_collector_c/nr_nas_sm5g_plain_ota_incoming_msg.h
@@ -29,7 +29,7 @@ _decode_nr_nas_sm5g_plain_ota_msg(const char* b, int offset, size_t length,
 
     size_t pdu_length = length - offset;
     PyObject* t = Py_BuildValue("(sy#s)",
-        "Msg", b + offset, pdu_length,
+        "Msg", b + offset, (Py_ssize_t)pdu_length,
         "raw_msg/nas-5gs");
     PyList_Append(result, t);
     Py_DECREF(t);

--- a/examples/capture_full_logs.py
+++ b/examples/capture_full_logs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+capture_full_logs.py - Capture MobileInsight logs directly from a phone via USB.
+This script enables detailed logging including LTE RRC, NAS, and MAC layers.
+
+Usage:
+    python capture_full_logs.py <serial_port> <baud_rate> [output_file]
+Example:
+    python capture_full_logs.py /dev/ttyUSB0 9600 my_capture.mi2log
+"""
+
+import sys
+import os
+from mobile_insight.monitor import OnlineMonitor
+from mobile_insight.analyzer import MsgLogger
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python capture_full_logs.py <serial_port> <baud_rate> [output_file]")
+        print("Example: python capture_full_logs.py /dev/ttyUSB0 9600 my_capture.mi2log")
+        sys.exit(1)
+
+    port = sys.argv[1]
+    baud = int(sys.argv[2])
+    
+    if len(sys.argv) >= 4:
+        output_file = sys.argv[3]
+    else:
+        output_file = "capture_mac_rrc.mi2log"
+
+    print(f"Starting capture on {port} at {baud} baud. Saving to {output_file}...")
+    print("Press Ctrl+C to stop recording.")
+
+    # Initialize monitor
+    src = OnlineMonitor()
+    src.set_serial_port(port)
+    src.set_baudrate(baud)
+    src.save_log_as(output_file)
+
+    # Enable detailed logs (RRC, NAS, and MAC)
+    logs_to_enable = [
+        # RRC
+        "LTE_RRC_OTA_Packet",
+        "LTE_RRC_Serv_Cell_Info",
+        "5G_NR_RRC_OTA_Packet",
+        "WCDMA_RRC_OTA_Packet",
+        
+        # NAS
+        "LTE_NAS_EMM_OTA_Incoming_Packet",
+        "LTE_NAS_EMM_OTA_Outgoing_Packet",
+        "LTE_NAS_ESM_OTA_Incoming_Packet",
+        "LTE_NAS_ESM_OTA_Outgoing_Packet",
+        
+        # MAC
+        "LTE_MAC_DL_Transport_Block",
+        "LTE_MAC_UL_Transport_Block",
+        "LTE_MAC_UL_Tx_Statistics",
+        "LTE_MAC_UL_Buffer_Status_Internal",
+        
+        # PHY (optional, disabled by default to save space, uncomment if needed)
+        # "LTE_PHY_Connected_Mode_Intra_Freq_Meas",
+        # "LTE_PHY_Serv_Cell_Measurement",
+    ]
+
+    for log_name in logs_to_enable:
+        src.enable_log(log_name)
+
+    # Optional: Dump to screen while capturing (Disable if it slows things down)
+    dumper = MsgLogger()
+    dumper.set_source(src)
+    dumper.set_decoding(MsgLogger.INFO)  # Change to MsgLogger.XML for verbose output
+
+    try:
+        src.run()
+    except KeyboardInterrupt:
+        print(f"\nCapture stopped. Saved to {output_file}")
+        sys.exit(0)

--- a/examples/mi2log_to_pcap.py
+++ b/examples/mi2log_to_pcap.py
@@ -39,16 +39,16 @@ GSMTAP_VERSION = 0x02
 GSMTAP_HDR_LEN = 4          # in 32-bit words (= 16 bytes)
 GSMTAP_TYPE_LTE_RRC = 13
 
-# GSMTAP LTE RRC sub-types (channel mapping)
+# GSMTAP LTE RRC sub-types (channel mapping based on Wireshark packet-gsmtap.c)
 GSMTAP_LTE_RRC_SUB = {
-    "BCCH_BCH":    0,
-    "BCCH_DL_SCH": 1,
-    "MCCH":        2,
-    "PCCH":        3,
-    "DL_CCCH":     4,
-    "DL_DCCH":     5,
-    "UL_CCCH":     6,
-    "UL_DCCH":     7,
+    "DL_CCCH":     0,
+    "DL_DCCH":     1,
+    "UL_CCCH":     2,
+    "UL_DCCH":     3,
+    "BCCH_BCH":    4,
+    "BCCH_DL_SCH": 5,
+    "PCCH":        6,
+    "MCCH":        7,
 }
 
 # Map AWW proto IDs/names to GSMTAP sub-types

--- a/examples/mi2log_to_pcap.py
+++ b/examples/mi2log_to_pcap.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+mi2log_to_pcap.py - Convert MobileInsight .mi2log files to Wireshark .pcap files
+
+Uses GSMTAP encapsulation (Ethernet + IPv4 + UDP:4729 + GSMTAP header) so that
+ANY standard Wireshark installation can decode the LTE RRC messages natively.
+
+Usage:
+    python mi2log_to_pcap.py <input.mi2log> [output.pcap]
+"""
+
+import sys
+import struct
+import xml.etree.ElementTree as ET
+from datetime import datetime
+
+# --- PERFORMANCE & CORRECTNESS HACK ---
+# MobileInsight's LogAnalyzer automatically passes raw LTE RRC packets to Wireshark 
+# (via ws_dissector) to get XML. We want the RAW bytes for GSMTAP.
+# Monkey-patching WSDissector skips the slow Wireshark call and preserves exact bytes!
+from mobile_insight.monitor.dm_collector.dm_endec.ws_dissector import WSDissector
+def raw_dummy_decode(msg_type, b):
+    # Store exact raw hex in a fake XML so LogAnalyzer doesn't crash
+    return f'<msg><packet><field name="aww.proto" show="{msg_type}"/><field name="lte-rrc.message" value="{b.hex()}"/></packet></msg>'
+WSDissector.decode_msg = staticmethod(raw_dummy_decode)
+# --------------------------------------
+
+from mobile_insight.analyzer import LogAnalyzer
+
+# PCAP constants
+PCAP_MAGIC = 0xa1b2c3d4
+PCAP_VERSION_MAJOR = 2
+PCAP_VERSION_MINOR = 4
+PCAP_SNAPLEN = 65535
+PCAP_LINKTYPE_ETHERNET = 1
+
+# GSMTAP constants
+GSMTAP_VERSION = 0x02
+GSMTAP_HDR_LEN = 4          # in 32-bit words (= 16 bytes)
+GSMTAP_TYPE_LTE_RRC = 13
+
+# GSMTAP LTE RRC sub-types (channel mapping)
+GSMTAP_LTE_RRC_SUB = {
+    "BCCH_BCH":    0,
+    "BCCH_DL_SCH": 1,
+    "MCCH":        2,
+    "PCCH":        3,
+    "DL_CCCH":     4,
+    "DL_DCCH":     5,
+    "UL_CCCH":     6,
+    "UL_DCCH":     7,
+}
+
+# Map AWW proto IDs/names to GSMTAP sub-types
+AWW_TO_GSMTAP = {
+    "LTE-RRC_PCCH": GSMTAP_LTE_RRC_SUB["PCCH"],
+    "LTE-RRC_DL_DCCH": GSMTAP_LTE_RRC_SUB["DL_DCCH"],
+    "LTE-RRC_UL_DCCH": GSMTAP_LTE_RRC_SUB["UL_DCCH"],
+    "LTE-RRC_BCCH_DL_SCH": GSMTAP_LTE_RRC_SUB["BCCH_DL_SCH"],
+    "LTE-RRC_DL_CCCH": GSMTAP_LTE_RRC_SUB["DL_CCCH"],
+    "LTE-RRC_UL_CCCH": GSMTAP_LTE_RRC_SUB["UL_CCCH"],
+}
+
+
+def write_pcap_global_header(f):
+    f.write(struct.pack('<IHHiIII',
+        PCAP_MAGIC, PCAP_VERSION_MAJOR, PCAP_VERSION_MINOR,
+        0, 0, PCAP_SNAPLEN, PCAP_LINKTYPE_ETHERNET))
+
+def write_pcap_packet(f, ts_sec, ts_usec, data):
+    f.write(struct.pack('<IIII', ts_sec, ts_usec, len(data), len(data)))
+    f.write(data)
+
+def build_gsmtap_header(gsmtap_type, sub_type, arfcn=0, frame_nr=0):
+    """Build a 16-byte GSMTAP header."""
+    return struct.pack('>BBBBHBBIBBB x',
+        GSMTAP_VERSION,    # version
+        GSMTAP_HDR_LEN,    # header length in 32-bit words
+        gsmtap_type,        # type (LTE_RRC = 13)
+        0,                  # timeslot
+        arfcn,              # ARFCN
+        0,                  # signal_dbm
+        0,                  # snr_db
+        frame_nr,           # frame number
+        sub_type,           # sub_type (channel)
+        0,                  # antenna_nr
+        0,                  # sub_slot
+    )
+
+def build_ethernet_ipv4_udp(payload):
+    """Wrap payload in Ethernet + IPv4 + UDP headers for GSMTAP (port 4729)."""
+    udp_len = 8 + len(payload)
+    udp_hdr = struct.pack('>HHHH', 4729, 4729, udp_len, 0)
+    
+    ip_total_len = 20 + udp_len
+    ip_hdr = struct.pack('>BBHHHBBHII',
+        0x45, 0, ip_total_len, 0, 0x4000, 64, 17, 0, 0x7f000001, 0x7f000001)
+    
+    eth_hdr = struct.pack('>6s6sH',
+        b'\x00'*6, b'\x00'*6, 0x0800)
+    return eth_hdr + ip_hdr + udp_hdr + payload
+
+def parse_timestamp(ts_str):
+    for fmt in ('%Y-%m-%d  %H:%M:%S.%f', '%Y-%m-%d %H:%M:%S.%f', '%Y-%m-%d  %H:%M:%S'):
+        try:
+            dt = datetime.strptime(ts_str.strip(), fmt)
+            epoch = datetime(1970, 1, 1)
+            delta = dt - epoch
+            return int(delta.total_seconds()), dt.microsecond
+        except ValueError:
+            continue
+    return 0, 0
+
+def extract_pdu_from_xml(payload_xml):
+    """Extract msg_type (AWW name) and raw PDU bytes from our monkey-patched XML."""
+    try:
+        root = ET.fromstring(payload_xml)
+    except ET.ParseError:
+        return None, None, 0, 0
+
+    msg_type = None
+    pdu_hex = None
+    arfcn = 0
+    frame_nr = 0
+
+    for pair in root.findall(".//pair"):
+        key = pair.get("key")
+        if key == "Freq" and pair.text:
+            try: arfcn = int(pair.text)
+            except: pass
+        elif key == "SysFrameNum/SubFrameNum" and pair.text:
+            try: frame_nr = int(pair.text)
+            except: pass
+
+    # Find the data inside our fake <msg><packet> structure
+    for field in root.findall(".//field"):
+        if field.get("name") == "aww.proto":
+            msg_type = field.get("show")
+        elif field.get("name") == "lte-rrc.message":
+            pdu_hex = field.get("value")
+
+    if msg_type and pdu_hex:
+        try:
+            return msg_type, bytes.fromhex(pdu_hex), arfcn, frame_nr
+        except ValueError:
+            pass
+    return None, None, 0, 0
+
+
+def convert_mi2log_to_pcap(input_path, output_path):
+    print(f"Loading {input_path}...")
+    def on_done(): pass
+    
+    # We load standard log analyzer, but because we monkey-patched WSDissector, 
+    # it runs instantly and yields the pure raw bytes inside a quick XML wrapper.
+    analyzer = LogAnalyzer(on_done)
+    analyzer.AnalyzeFile([input_path], analyzer.supported_types)
+
+    if not analyzer.msg_logs:
+        print("Error: No messages found.")
+        return False
+
+    rrc_msgs = [m for m in analyzer.msg_logs if m.get('TypeID') == 'LTE_RRC_OTA_Packet']
+    print(f"Found {len(analyzer.msg_logs)} total messages, {len(rrc_msgs)} LTE_RRC_OTA_Packet messages")
+
+    exported = 0
+    skipped = 0
+
+    with open(output_path, 'wb') as f:
+        write_pcap_global_header(f)
+
+        for msg in rrc_msgs:
+            payload = msg.get('Payload', '')
+            timestamp = msg.get('Timestamp', '')
+
+            msg_type, pdu_bytes, arfcn, frame_nr = extract_pdu_from_xml(payload)
+            if msg_type is None or pdu_bytes is None:
+                skipped += 1
+                continue
+
+            gsmtap_sub = AWW_TO_GSMTAP.get(msg_type)
+            if gsmtap_sub is None:
+                skipped += 1
+                continue
+
+            gsmtap_hdr = build_gsmtap_header(GSMTAP_TYPE_LTE_RRC, gsmtap_sub, arfcn, frame_nr)
+            gsmtap_pkt = gsmtap_hdr + pdu_bytes
+            eth_frame = build_ethernet_ipv4_udp(gsmtap_pkt)
+
+            ts_sec, ts_usec = parse_timestamp(timestamp)
+            write_pcap_packet(f, ts_sec, ts_usec, eth_frame)
+            exported += 1
+
+    print(f"\nExported {exported} packets to {output_path}")
+    if skipped:
+        print(f"Skipped {skipped} packets (NB-IoT or unsupported channel)")
+    print(f"\nOpen with: wireshark {output_path}")
+    return exported > 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <input.mi2log> [output.pcap]")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2] if len(sys.argv) >= 3 else input_file.rsplit('.', 1)[0] + '.pcap'
+    success = convert_mi2log_to_pcap(input_file, output_file)
+    sys.exit(0 if success else 1)

--- a/gui/mobile_insight_gui.py
+++ b/gui/mobile_insight_gui.py
@@ -174,12 +174,21 @@ class WindowClass(wx.Frame):
         openItem = fileButton.Append(ID_FILE_OPEN, "Open", "Open log file")
         exitItem = fileButton.Append(ID_FILE_EXIT, "Exit", "Exit application")
 
+        filterItem = editButton.Append(wx.ID_ANY, "Filter", "Filter log messages")
+        searchItem = editButton.Append(wx.ID_ANY, "Search", "Search in log messages")
+        timeItem = editButton.Append(wx.ID_ANY, "Time Window", "Select time window")
+        resetItem = editButton.Append(wx.ID_ANY, "Reset", "Reset filters and search")
+
         menuBar.Append(fileButton, 'File')
         menuBar.Append(editButton, "Edit")
         self.SetMenuBar(menuBar)
 
         self.Bind(wx.EVT_MENU, self.Quit, exitItem)
         self.Bind(wx.EVT_MENU, self.Open, openItem)
+        self.Bind(wx.EVT_MENU, self.OnFilter, filterItem)
+        self.Bind(wx.EVT_MENU, self.OnSearch, searchItem)
+        self.Bind(wx.EVT_MENU, self.OnTime, timeItem)
+        self.Bind(wx.EVT_MENU, self.OnReset, resetItem)
 
         # Toolbar
         self.toolbar = self.CreateToolBar(
@@ -219,7 +228,7 @@ class WindowClass(wx.Frame):
         mainSizer = wx.BoxSizer(wx.HORIZONTAL)
 
         hbox = wx.BoxSizer(wx.HORIZONTAL)
-        self.grid = wx.grid.Grid(self)
+        self.grid = wx.grid.Grid(panel)
         self.grid.CreateGrid(50, 2)
         self.grid.SetSelectionMode(1)  # 1 is Select Row
 
@@ -229,7 +238,7 @@ class WindowClass(wx.Frame):
 
         hbox.Add(self.grid, 5, wx.EXPAND | wx.ALL, 10)
 
-        leftPanel = wx.Panel(self, -1, size=(-1, -1), style=wx.BORDER_RAISED)
+        leftPanel = wx.Panel(panel, -1, size=(-1, -1), style=wx.BORDER_RAISED)
 
         leftbox = wx.BoxSizer(wx.VERTICAL)
         self.status_text = wx.StaticText(
@@ -374,6 +383,9 @@ class WindowClass(wx.Frame):
     def OnGridSelect(self, e):
         # self.statusbar.SetStatusText("Selected %d" %e.GetRow())
         row = e.GetRow()
+        if not hasattr(self, 'data_view') or not self.data_view:
+            e.Skip()
+            return
         if (row < len(self.data_view)):
             self.status_text.SetLabel(
                 "Time Stamp : %s    Type : %s" %


### PR DESCRIPTION
- Add PY_SSIZE_T_CLEAN macro to all C extension source files
- Cast length arguments to Py_ssize_t in all Py_BuildValue y#/s# calls
- Add LteRrcOtaPacketFmt_v27 format definition and decoding logic
- Fix GUI: populate empty Edit menu with Filter/Search/Time/Reset
- Fix GUI: add data_view guard in OnGridSelect to prevent crashes